### PR TITLE
Fix namespace problem in naoqi_camera

### DIFF
--- a/naoqi_sensors/src/naoqi_camera.cpp
+++ b/naoqi_sensors/src/naoqi_camera.cpp
@@ -128,7 +128,7 @@ namespace naoqicamera_driver
    * @param nh Nodehandle used to get parameters
    *
    */
-  void NaoCameraDriver::getNaoqiParams(ros::NodeHandle nh)
+  void NaoqiCameraDriver::getNaoqiParams(ros::NodeHandle nh)
   {
     if( !nh.getParam("pip", m_pip) )
       ROS_WARN("No pip parameter specified.");


### PR DESCRIPTION
The new method getNaoqiParams did not take into account the namespace
change done using repo restructuring. Here the correct namespace is
used for the method.
