### PR TITLE
naoqui_tools not depending on robot descriptions

### DIFF
--- a/naoqi_tools/package.xml
+++ b/naoqi_tools/package.xml
@@ -16,7 +16,4 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend>nao_description</run_depend>
-  <run_depend>romeo_description</run_depend>
-
 </package>


### PR DESCRIPTION
I was gonna test Nao in ROS and, hopefully, in Gazebo. I didn't find any updated guide on that so I'm just debugging as I work.

I did a:

```
rosdep install --from-paths src --ignore-src --rosdistro hydro -y
```

On a workspace with only `nao_robot` and `naoqi_bridge` and I got:

```
ERROR: the following packages/stacks could not have their rosdep keys resolved to system dependencies:
naoqi_tools: Cannot locate rosdep definition for [romeo_description]
```

As it's named "tools" I think that maybe it shouldn't depend on the robots descriptions (or you'll need all of them in the workspace!).
