### PR TITLE
Added missing rule for NaoqiCameraConfig

### DIFF
--- a/naoqi_sensors/CMakeLists.txt
+++ b/naoqi_sensors/CMakeLists.txt
@@ -63,6 +63,7 @@ if( ${NAOqi_FOUND} AND ${Boost_FOUND} )
         ${Boost_LIBRARIES}
         ${NAOqi_LIBRARIES})
     add_dependencies(cameras ${catkin_EXPORTED_TARGETS})
+    add_dependencies(cameras ${PROJECT_NAME}_gencfg)
 
     install(TARGETS cameras
         RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION} )


### PR DESCRIPTION
Because it said the file naoqi_sensors/NaoqiCameraConfig.h was missing.

Using Ubuntu 14.04 and ROS Indigo.

With this fix it compiles.
