### PR TITLE
Fix camera node for NAO version 3.2 with Naoqi 1.14. 

### DIFF
--- a/naoqi_sensors/cfg/NaoqiCamera.cfg
+++ b/naoqi_sensors/cfg/NaoqiCamera.cfg
@@ -102,7 +102,7 @@ gen.add("auto_exposition", int_t, SensorLevels.RECONFIGURE_RUNNING,
         "Auto exposition.", 1, 0, 1, edit_method = controls)
 
 gen.add("auto_exposure_algo", int_t, SensorLevels.RECONFIGURE_RUNNING,
-        "Auto Exposure Algorithm.", 1, 0, 3, edit_method = exposure_algos)
+        "Auto Exposure Algorithm.", 1, 0, 0, edit_method = exposure_algos)
 
 gen.add("exposure", int_t, SensorLevels.RECONFIGURE_RUNNING,
         "Exposure (time in ms = (value * 2) / 5) (disables auto exposition)", 128, 0, 512)

--- a/naoqi_sensors/launch/camera.launch
+++ b/naoqi_sensors/launch/camera.launch
@@ -10,7 +10,7 @@
   <arg name="frame_rate" default="15" />
   <arg name="use_ros_time" default="True" />
   <arg name="auto_exposition" default="1" />
-  <arg name="auto_exposure_algo" default="3" />
+  <arg name="auto_exposure_algo" default="0" />
   <arg name="exposure" default="128" />
   <arg name="gain" default="128" />
   <arg name="brightness" default="128" />

--- a/naoqi_sensors/src/naoqi_sensors/naoqi_camera.py
+++ b/naoqi_sensors/src/naoqi_sensors/naoqi_camera.py
@@ -135,14 +135,9 @@ class NaoqiCam (NaoqiNode):
 
         if is_camera_new:
             rospy.loginfo('subscribed to camera proxy, since this is the first camera')
-            if self.get_version() < LooseVersion('2.0'):
-                self.nameId = self.camProxy.subscribe("rospy_gvm", new_config['source'],
-                                                      new_config['resolution'], new_config['color_space'],
-                                                      new_config['frame_rate'])
-            else:
-                self.nameId = self.camProxy.subscribeCamera("rospy_gvm", new_config['source'],
-                                                            new_config['resolution'], new_config['color_space'],
-                                                            new_config['frame_rate'])
+            self.nameId = self.camProxy.subscribeCamera("rospy_gvm", new_config['source'],
+                                                        new_config['resolution'], new_config['color_space'],
+                                                        new_config['frame_rate'])
 
         if self.config['source'] != new_config['source'] or is_camera_new:
             rospy.loginfo('updating camera source information')


### PR DESCRIPTION
Changed the camProxy.subscribe() which was deprecated to the subscribeCamera, and as the call was the same for both versions removed the if for the version. 

Also changed the auto_Exposure_algo parameter to 0 as the parameters 2 and 3 were not valid for this NAO model (it gave an error), so parameter 0 and 1 should work for every NAO.
