### PR TITLE
use rosparam to setup AK memory key or topic name to publish

### DIFF
--- a/naoqi_sensors/nodes/sonar.py
+++ b/naoqi_sensors/nodes/sonar.py
@@ -22,16 +22,22 @@ import rospy
 from naoqi_sensors.naoqi_sonar import SonarSensor, SonarPublisher
 
 if __name__ == '__main__':
-    # create two sonars
-    leftSonar = SonarSensor('Device/SubDeviceList/US/Left/Sensor/Value',     # AL memory key
-                            'LSonar_frame',                                        # ROS frame id
-                            '~/nao/sonar_left')                              # ROS topic to publish
+    sonar_params = rospy.get_param('sonar_devices', [{'al_memory_key': 'Device/SubDeviceList/US/Left/Sensor/Value',
+                                                      'frame_id': 'LSonar_frame',
+                                                      'topic_name': '~/nao/sonar_left'},
+                                                     {'al_memory_key': 'Device/SubDeviceList/US/Right/Sensor/Value',
+                                                      'frame_id': 'RSonar_frame',
+                                                      'topic_name': '~/nao/sonar_right'}])
+    sonars = []
+    for param in sonar_params:
+        print("{}: {} {}".format(param['al_memory_key'], param['frame_id'],param['topic_name']))
+        sonar = SonarSensor(param['al_memory_key'],     # AL memory key
+                            param['frame_id'],          # ROS frame_id
+                            param['topic_name'])        # ROS topic to publish
+        sonars.append(sonar)
+    sonars = tuple(sonars)
 
-    rightSonar = SonarSensor('Device/SubDeviceList/US/Right/Sensor/Value',   # AL memory key
-                             'RSonar_frame',                                       # ROS frame id
-                             '~/nao/sonar_right')                            # ROS topic to publish
-
-    publisher = SonarPublisher( (leftSonar,rightSonar))                      # list of sonars
+    publisher = SonarPublisher( sonars )                      # list of sonars
     publisher.start()
 
     rospy.spin()


### PR DESCRIPTION
example of using this node on different naoqi robot

```
<node pkg="naoqi_sensors" type="sonar.py" name="nao_sonar" args="--pip=$(arg nao_ip) --pport=$(arg nao_port)" output="screen" >
    <rosparam ns="/" >                                                                                                                             
      sonar_devices: [{al_memory_key: Device/SubDeviceList/Platform/Front/Sonar/Sensor/Value, 'frame_id': 'SonarLFront_frame', 'topic_name': '~/pe\
pper/sonar/front'}, {al_memory_key: Device/SubDeviceList/Platform/Front/Sonar/Sensor/Value, 'frame_id': 'SonarBack_frame', 'topic_name': '~/peppr/\
sonar/back'}]                                                                                                                                      
    </rosparam>
  </node>
```
