### PR TITLE
use 16UC1 as kinect do

### DIFF
--- a/naoqi_sensors/src/naoqi_sensors/naoqi_camera.py
+++ b/naoqi_sensors/src/naoqi_sensors/naoqi_camera.py
@@ -252,7 +252,7 @@ class NaoqiCam (NaoqiNode):
             elif image[3] == kYUV422ColorSpace:
                 encoding = "yuv422" # this works only in ROS groovy and later
             elif image[3] == kDepthColorSpace:
-                encoding = "mono16"
+                encoding = "16UC1"
             else:
                 rospy.logerr("Received unknown encoding: {0}".format(image[3]))
             img.encoding = encoding


### PR DESCRIPTION
we have trouble on using https://github.com/ros-perception/image_pipeline/blob/indigo/depth_image_proc/src/nodelets/point_cloud_xyz.cpp to convert depth to pointcloud converter due to unsupported image type. I'm not sure if this is correct solution, but at least kinect publishes it's depth image with 16UC1.
