### PR TITLE
Update camera nodelet names

### DIFF
--- a/naoqi_sensors/launch/nodelet_manager.launch
+++ b/naoqi_sensors/launch/nodelet_manager.launch
@@ -13,8 +13,8 @@
         args="manager" />
 
   <!-- camera driver nodelet -->
-  <node pkg="nodelet" type="nodelet" name="naocamera_nodelet"
-        args="load naocamera/driver camera_nodelet_manager" >
+  <node pkg="nodelet" type="nodelet" name="naoqicamera_nodelet"
+        args="load naoqicamera/driver camera_nodelet_manager" >
   </node>
 
 </launch>

--- a/naoqi_sensors/launch/nodelet_standalone.launch
+++ b/naoqi_sensors/launch/nodelet_standalone.launch
@@ -8,8 +8,8 @@
 
 <launch>
 
-  <node pkg="nodelet" type="nodelet" name="naocamera_nodelet"
-        args="standalone naocamera/driver" >
+  <node pkg="nodelet" type="nodelet" name="naoqicamera_nodelet"
+        args="standalone naoqicamera/driver" >
   </node>
 
 </launch>

--- a/naoqi_sensors/naoqicamera_nodelet.xml
+++ b/naoqi_sensors/naoqicamera_nodelet.xml
@@ -1,6 +1,6 @@
-<library path="lib/libnaocamera_nodelet">
-  <class name="naocamera/driver"
-         type="NaoCameraNodelet"
+<library path="lib/libnaoqicamera_nodelet">
+  <class name="naoqicamera/driver"
+         type="NaoqiCameraNodelet"
          base_class_type="nodelet::Nodelet">
     <description> 
       Driver nodelet for Aldebaran's NAO cameras.

--- a/naoqi_sensors/src/naoqi_camera.cpp
+++ b/naoqi_sensors/src/naoqi_camera.cpp
@@ -190,9 +190,9 @@ namespace naoqicamera_driver
         camera_proxy_ = boost::shared_ptr<ALVideoDeviceProxy>(new ALVideoDeviceProxy(m_broker));
 
         if (camera_proxy_->getGenericProxy()->isLocal())
-            ROS_INFO("nao_camera runs directly on the robot.");
+            ROS_INFO("naoqi_camera runs directly on the robot.");
         else
-            ROS_WARN("nao_camera runs remotely.");
+            ROS_WARN("naoqi_camera runs remotely.");
         // build a unique name for the camera that will be used to
         // store calibration informations.
         stringstream canonical_name;

--- a/naoqi_sensors/src/naoqi_camera.cpp
+++ b/naoqi_sensors/src/naoqi_camera.cpp
@@ -528,4 +528,4 @@ namespace naoqicamera_driver
     closeCamera();
   }
 
-}; // end namespace naocamera_driver
+}; // end namespace naoqicamera_driver

--- a/naoqi_sensors/src/naoqi_camera.h
+++ b/naoqi_sensors/src/naoqi_camera.h
@@ -133,6 +133,6 @@ private:
   double topic_diagnostics_max_freq_;
   diagnostic_updater::TopicDiagnostic topic_diagnostics_;
 
-}; // end class NaoCameraDriver
+}; // end class NaoqiCameraDriver
 
-}; // end namespace naocamera_driver
+}; // end namespace naoqicamera_driver


### PR DESCRIPTION
The xml metadata file for the naoqi_camera nodelet is not up to date, it uses the old nao_camera name.
Here it is updated so that loading the nodelet works, note that launchfiles also needs to be updated.
