### PR TITLE
Move generate_urdf.py system bin dir to package bin dir

### DIFF
--- a/naoqi_tools/CMakeLists.txt
+++ b/naoqi_tools/CMakeLists.txt
@@ -16,7 +16,7 @@ catkin_python_setup()
 
 include_directories(${catkin_INCLUDE_DIRS})
 
-install(PROGRAMS
+catkin_install_python(PROGRAMS
   scripts/generate_urdf.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/naoqi_tools/CMakeLists.txt
+++ b/naoqi_tools/CMakeLists.txt
@@ -16,3 +16,7 @@ catkin_python_setup()
 
 include_directories(${catkin_INCLUDE_DIRS})
 
+install(PROGRAMS
+  scripts/generate_urdf.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/naoqi_tools/setup.py
+++ b/naoqi_tools/setup.py
@@ -5,7 +5,6 @@ from catkin_pkg.python_setup import generate_distutils_setup
 d = generate_distutils_setup(
     packages=['naoqi_tools'],
     package_dir={'': 'src'},
-    scripts=['scripts/generate_urdf.py']
 )
 
 setup(**d)


### PR DESCRIPTION
generate_urdf.py is installed in /opt/indigo/bin.
The document says that

rosrun naoqi_tool generate_urdf.py

but, it fails, because it is not in /opt/indigo/lib/naoqi_tool/.

At first, all packages should not use /opt/indigo/bin normally.
