### PR TITLE
Fix time conversion in cpp camera driver

### DIFF
--- a/naoqi_sensors/src/naoqi_camera.cpp
+++ b/naoqi_sensors/src/naoqi_camera.cpp
@@ -373,8 +373,7 @@ namespace naoqicamera_driver
             image->header.stamp = ros::Time::now();
         else { 
             // use NAOqi timestamp
-            image->header.stamp = ros::Time(((double)al_image[4]) +
-                ((double)al_image[5]) / 1000000.0);
+            image->header.stamp = ros::Time(al_image[4], al_image[5] * 1000);
         }
 
         image->width = (int) al_image[0];

--- a/naoqi_sensors/src/naoqi_camera.cpp
+++ b/naoqi_sensors/src/naoqi_camera.cpp
@@ -373,7 +373,8 @@ namespace naoqicamera_driver
             image->header.stamp = ros::Time::now();
         else { 
             // use NAOqi timestamp
-            image->header.stamp = ros::Time(((double) al_image[4] / 1000000.0) + (double) al_image[5]);
+            image->header.stamp = ros::Time(((double)al_image[4]) +
+                ((double)al_image[5]) / 1000000.0);
         }
 
         image->width = (int) al_image[0];


### PR DESCRIPTION
The timestamp of the image and diagnostic messages from the cpp driver of the
camera contains "random" data.

The Aldebaran doc [1,2] states that element 4 contains seconds and element 5
contains microseconds. In the code these are swapped. Also see the python
node where the conversion is done correctly.

[1] http://doc.aldebaran.com/2-1/naoqi/vision/alvideodevice-api.html#image
[2] http://doc.aldebaran.com/1-14/naoqi/vision/alvideodevice-api.html#image