### PR TITLE
[naoqi_apps] added two services and one topic related to external collision avoidance

### DIFF
--- a/naoqi_apps/launch/externalCollisionAvoidance.launch
+++ b/naoqi_apps/launch/externalCollisionAvoidance.launch
@@ -1,5 +1,5 @@
 <launch>
-  <!--
+    <!--
   	This pushes the local PYTHONPATH into the launch file, so that the NaoQI API is found.
     You need to add the Nao's API dir to your PYTHONPATH so that the modules are found.
   -->
@@ -8,5 +8,5 @@
   <arg name="nao_ip" default="$(optenv NAO_IP 127.0.0.1)" />
   <arg name="nao_port" default="$(optenv NAO_PORT 9559)" />
 
-  <node pkg="naoqi_apps" type="naoqi_externalCollisionAvoidance.py" name="naoqi_externalCollisionAvoidance" required="true" args="--pip=$(arg nao_ip) --pport=$(arg nao_port)"  />
+  <node pkg="naoqi_apps" type="naoqi_externalCollisionAvoidance.py" name="naoqi_externalCollisionAvoidance" required="true" args="--pip=$(arg nao_ip) --pport=$(arg nao_port)" output="screen" />
 </launch>

--- a/naoqi_apps/launch/externalCollisionAvoidance.launch
+++ b/naoqi_apps/launch/externalCollisionAvoidance.launch
@@ -1,0 +1,12 @@
+<launch>
+  <!--
+  	This pushes the local PYTHONPATH into the launch file, so that the NaoQI API is found.
+    You need to add the Nao's API dir to your PYTHONPATH so that the modules are found.
+  -->
+  <env name="PYTHONPATH" value="$(env PYTHONPATH)" />
+
+  <arg name="nao_ip" default="$(optenv NAO_IP 127.0.0.1)" />
+  <arg name="nao_port" default="$(optenv NAO_PORT 9559)" />
+
+  <node pkg="naoqi_apps" type="naoqi_externalCollisionAvoidance.py" name="naoqi_externalCollisionAvoidance" required="true" args="--pip=$(arg nao_ip) --pport=$(arg nao_port)"  />
+</launch>

--- a/naoqi_apps/nodes/naoqi_externalCollisionAvoidance.py
+++ b/naoqi_apps/nodes/naoqi_externalCollisionAvoidance.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python
+
+#
+# ROS node to set Pepper's orthogonal security distance, tangential security 
+# distance and read move faied information
+# This code is currently compatible to NaoQI version 2.3
+#
+# Copyright 2015 Kanae Kochigami, The University of Tokyo
+# http://wiki.ros.org/pepper
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    # Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#    # Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#    # Neither the name of the University of Freiburg nor the names of its
+#       contributors may be used to endorse or promote products derived from
+#       this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+import rospy
+import sys
+import naoqi
+from naoqi_driver.naoqi_node import NaoqiNode
+from naoqi import ( ALModule, ALBroker, ALProxy )
+from std_msgs.msg import String 
+from std_srvs.srv import (
+    EmptyResponse,
+    Empty)
+#from naoqi_bridge_msgs.srv import SetArmsEnabled
+from naoqi_bridge_msgs.srv import ( TangentialSecurityDistance, OrthogonalSecurityDistance )
+
+#
+# Notes:
+# - A port number > 0 for the module must be specified.
+#   If port 0 is used, a free port will be assigned automatically,
+#   but naoqi is unable to pick up the assigned port number, leaving
+#   the module unable to communicate with naoqi (1.10.52).
+#
+# - Callback functions _must_ have a docstring, otherwise they won't get bound.
+#
+# - Shutting down the broker manually will result in a deadlock,
+#   not shutting down the broker will sometimes result in an exception
+#   when the script ends (1.10.52).
+#
+
+class NaoqiExternalCollisionAvoidance(ALModule):
+    "Sends callbacks for bumper failed information to ROS"
+    def __init__(self, moduleName):
+        # get connection from command line:
+        from optparse import OptionParser
+
+        parser = OptionParser()
+        parser.add_option("--ip", dest="ip", default="",
+                          help="IP/hostname of broker. Default is system's default IP address.", metavar="IP")
+        parser.add_option("--port", dest="port", default=0,
+                          help="IP/hostname of broker. Default is automatic port.", metavar="PORT")
+        parser.add_option("--pip", dest="pip", default="127.0.0.1",
+                          help="IP/hostname of parent broker. Default is 127.0.0.1.", metavar="IP")
+        parser.add_option("--pport", dest="pport", default=9559,
+                          help="port of parent broker. Default is 9559.", metavar="PORT")
+
+        (options, args) = parser.parse_args()
+        self.ip = options.ip
+        self.port = int(options.port)
+        self.pip = options.pip
+        self.pport = int(options.pport)
+        self.moduleName = moduleName
+
+        self.init_almodule()
+
+        # ROS initialization:
+        rospy.init_node('naoqi_externalCollisionAvoidance')
+
+        # init. messages:
+        self.moveFailed = String()
+        
+        self.setOrthogonalSecurityDistanceSrv = rospy.Service("naoqi_externalCollisionAvoidance/orthogonal_distance", OrthogonalSecurityDistance, self.handleOrthogonalSecurityDistanceSrv)
+        self.setTangentialSecurityDistanceSrv = rospy.Service("naoqi_externalCollisionAvoidance/tangential_distance", TangentialSecurityDistance, self.handleTangentialSecurityDistanceSrv)
+        self.moveFailedPub = rospy.Publisher("move_failed", String, queue_size=10)
+        
+        self.subscribe()
+
+        rospy.loginfo("nao_externalCollisionAvoidance initialized")
+
+    def init_almodule(self):
+        # before we can instantiate an ALModule, an ALBroker has to be created
+        rospy.loginfo("Connecting to NaoQi at %s:%d", self.pip, self.pport)
+        try:
+            self.broker = ALBroker("%sBroker" % self.moduleName, self.ip, self.port, self.pip, self.pport)
+        except RuntimeError,e:
+            print("Could not connect to NaoQi's main broker")
+            exit(1)
+        ALModule.__init__(self, self.moduleName)
+
+        self.memProxy = ALProxy("ALMemory", self.pip, self.pport)
+        # TODO: check self.memProxy.version() for > 1.6
+        if self.memProxy is None:
+            rospy.logerror("Could not get a proxy to ALMemory on %s:%d", self.pip, self.pport)
+            exit(1)
+        self.motionProxy = ALProxy("ALMotion", self.pip, self.pport)
+
+
+    def shutdown(self):
+        self.unsubscribe()
+        # Shutting down broker seems to be not necessary any more
+        # try:
+        #     self.broker.shutdown()
+        # except RuntimeError,e:
+        #     rospy.logwarn("Could not shut down Python Broker: %s", e)
+
+
+    def subscribe(self):
+        self.memProxy.subscribeToEvent("ALMotion/MoveFailed", self.moduleName, "onMoveFailed")
+        
+
+    def unsubscribe(self):
+        self.memProxy.unsubscribeToEvent("ALMotion/MoveFailed", self.moduleName)
+
+    def handleOrthogonalSecurityDistanceSrv(self, req):
+        if (req.orthogonal_distance < 0.001 or req.orthogonal_distance == 0.001):
+            return EmptyResponse
+        self.motionProxy.setOrthogonalSecurityDistance(req.orthogonal_distance.data)
+        return EmptyResponse
+
+    def handleTangentialSecurityDistanceSrv(self, req):
+        if (req.tangential_distance < 0.001 or req.tangential_distance == 0.001):
+            return EmptyResponse
+        self.motionProxy.setTangentialSecurityDistance(req.tangential_distance.data)
+        return EmptyResponse
+
+    def onMoveFailed(self, strVarName, value, strMessage):
+        "Called when ALMotion/MoveFailed event is raised in ALMemory"
+        publish_message = "Cause of move failed: " + value[0]
+        if value[1] == 0:
+            publish_message += ", Status: move not started" 
+        if value[1] == 1:
+            publish_message += ", Status: move started but stopped" 
+    
+        publish_message += ", Obstacle position: "+ str(value[2])
+        self.moveFailed.data = publish_message;
+        self.moveFailedPub.publish(self.moveFailed)
+        rospy.logdebug("move failed: name=%s, value=%s, message=%s.", strVarName, value, strMessage);
+
+
+if __name__ == '__main__':
+    ROSNaoqiExternalCollisionAvoidanceModule = NaoqiExternalCollisionAvoidance("ROSNaoqiExternalCollisionAvoidanceModule")
+
+    rospy.spin()
+
+    rospy.loginfo("Stopping naoqi_externalCollisionAvoidance ...")
+    ROSNaoqiExternalCollisionAvoidanceModule.shutdown();
+    rospy.loginfo("naoqi_externalCollisionAvoidance stopped.")
+    exit(0)

--- a/naoqi_apps/nodes/naoqi_externalCollisionAvoidance.py
+++ b/naoqi_apps/nodes/naoqi_externalCollisionAvoidance.py
@@ -150,11 +150,10 @@ class NaoqiExternalCollisionAvoidance(NaoqiNode):
                 target_name = "LArm"
             if req.name.data == 4:
                 target_name = "RArm"
-            if self.motionProxy.getExternalCollisionProtectionEnabled(target_name)== True: 
-                rospy.loginfo("Current External Collision Protection Status of " + target_name + ": Enabled")
-            else:
-                rospy.loginfo("Current External Collision Protection Status of " + target_name + ": Disabled")
-            return GetExternalCollisionProtectionEnabledResponse()
+            res = GetExternalCollisionProtectionEnabledResponse()
+            res.status = self.motionProxy.getExternalCollisionProtectionEnabled(target_name)
+            rospy.loginfo("Current External Collision Protection Status of " + target_name + ": " + str (res.status))
+            return res
         except RuntimeError, e:
             rospy.logerr("Exception caught:\n%s", e)
             return None

--- a/naoqi_apps/nodes/naoqi_externalCollisionAvoidance.py
+++ b/naoqi_apps/nodes/naoqi_externalCollisionAvoidance.py
@@ -113,39 +113,42 @@ class NaoqiExternalCollisionAvoidance(NaoqiNode):
 
     def handleSetExternalCollisionProtectionEnabled(self, req):
         try:
-            if req.name.number == 0:
+            if req.name.data == 0:
                 target_name = "All"
-            if req.name.number == 1:
+            if req.name.data == 1:
                 target_name = "Move"
-            if req.name.number == 2:
+            if req.name.data == 2:
                 target_name = "Arms"
-            if req.name.number == 3:
+            if req.name.data == 3:
                 target_name = "LArm"
-            if req.name.number == 4:
+            if req.name.data == 4:
                 target_name = "RArm"
-            self.motionProxy.setExternalCollisionProtectionEnabled(target_name, req.status)
-            if self.motionProxy.getExternalCollisionProtectionEnabled(target_name)== True:
-                rospy.loginfo("Current External Collision Protection Status of " + target_name + ": Enabled")
-            else:
-                rospy.loginfo("Current External Collision Protection Status of " + target_name + ": Disabled")
-                if (target_name == "All" or target_name == "Move") and req.status == False:
-                    rospy.loginfo("CAUTION: YOU DEACTIVATED SAFETY REFLEXES. BE CAREFUL TO THE SAFETY OF THE ROBOT AND PEOPLE.")
-            return SetExternalCollisionProtectionEnabledResponse()
+            res = SetExternalCollisionProtectionEnabledResponse()
+            res.status = False
+            if self.motionProxy.setExternalCollisionProtectionEnabled(target_name, req.status) == None:
+                res.status = True
+                if self.motionProxy.getExternalCollisionProtectionEnabled(target_name)== True:
+                    rospy.loginfo("Current External Collision Protection Status of " + target_name + ": Enabled")
+                else:
+                    rospy.loginfo("Current External Collision Protection Status of " + target_name + ": Disabled")
+                    if (target_name == "All" or target_name == "Move") and req.status == False:
+                        rospy.loginfo("CAUTION: YOU DEACTIVATED SAFETY REFLEXES. BE CAREFUL TO THE SAFETY OF THE ROBOT AND PEOPLE.")
+            return res
         except RuntimeError, e:
             rospy.logerr("Exception caught:\n%s", e)
-            return None
+            return res
 
     def handleGetExternalCollisionProtectionEnabled(self, req):
         try:
-            if req.name.number == 0:
+            if req.name.data == 0:
                 target_name = "All"
-            if req.name.number == 1:
+            if req.name.data == 1:
                 target_name = "Move"
-            if req.name.number == 2:
+            if req.name.data == 2:
                 target_name = "Arms"
-            if req.name.number == 3:
+            if req.name.data == 3:
                 target_name = "LArm"
-            if req.name.number == 4:
+            if req.name.data == 4:
                 target_name = "RArm"
             if self.motionProxy.getExternalCollisionProtectionEnabled(target_name)== True: 
                 rospy.loginfo("Current External Collision Protection Status of " + target_name + ": Enabled")

--- a/naoqi_apps/nodes/naoqi_externalCollisionAvoidance.py
+++ b/naoqi_apps/nodes/naoqi_externalCollisionAvoidance.py
@@ -1,169 +1,151 @@
 #!/usr/bin/env python
 
-#
-# ROS node to set Pepper's orthogonal security distance, tangential security 
-# distance and read move faied information
-# This code is currently compatible to NaoQI version 2.3
-#
-# Copyright 2015 Kanae Kochigami, The University of Tokyo
-# http://wiki.ros.org/pepper
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-#    # Redistributions of source code must retain the above copyright
-#       notice, this list of conditions and the following disclaimer.
-#    # Redistributions in binary form must reproduce the above copyright
-#       notice, this list of conditions and the following disclaimer in the
-#       documentation and/or other materials provided with the distribution.
-#    # Neither the name of the University of Freiburg nor the names of its
-#       contributors may be used to endorse or promote products derived from
-#       this software without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
-#
-
+#                                                                             
+#  Copyright 2015 Aldebaran                                                   
+#                                                                             
+#  Licensed under the Apache License, Version 2.0 (the "License");            
+#  you may not use this file except in compliance with the License.           
+#  You may obtain a copy of the License at                                    
+#                                                                             
+#      http://www.apache.org/licenses/LICENSE-2.0                             
+#                                                                             
+#  Unless required by applicable law or agreed to in writing, software        
+#  distributed under the License is distributed on an "AS IS" BASIS,          
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   
+#  See the License for the specific language governing permissions and        
+#  limitations under the License.                                             
+#                                                                             
+# 
 import rospy
-import sys
-import naoqi
 from naoqi_driver.naoqi_node import NaoqiNode
-from naoqi import ( ALModule, ALBroker, ALProxy )
 from std_msgs.msg import String 
 from std_srvs.srv import (
     EmptyResponse,
     Empty)
-#from naoqi_bridge_msgs.srv import SetArmsEnabled
-from naoqi_bridge_msgs.srv import ( TangentialSecurityDistance, OrthogonalSecurityDistance )
+from naoqi_bridge_msgs.srv import ( 
+    TangentialSecurityDistanceResponse,
+    TangentialSecurityDistance, 
+    OrthogonalSecurityDistanceResponse,
+    OrthogonalSecurityDistance,
+    SetExternalCollisionProtectionEnabledResponse,
+    SetExternalCollisionProtectionEnabled,
+    GetExternalCollisionProtectionEnabledResponse,
+    GetExternalCollisionProtectionEnabled,)
 
-#
-# Notes:
-# - A port number > 0 for the module must be specified.
-#   If port 0 is used, a free port will be assigned automatically,
-#   but naoqi is unable to pick up the assigned port number, leaving
-#   the module unable to communicate with naoqi (1.10.52).
-#
-# - Callback functions _must_ have a docstring, otherwise they won't get bound.
-#
-# - Shutting down the broker manually will result in a deadlock,
-#   not shutting down the broker will sometimes result in an exception
-#   when the script ends (1.10.52).
-#
-
-class NaoqiExternalCollisionAvoidance(ALModule):
-    "Sends callbacks for bumper failed information to ROS"
-    def __init__(self, moduleName):
-        # get connection from command line:
-        from optparse import OptionParser
-
-        parser = OptionParser()
-        parser.add_option("--ip", dest="ip", default="",
-                          help="IP/hostname of broker. Default is system's default IP address.", metavar="IP")
-        parser.add_option("--port", dest="port", default=0,
-                          help="IP/hostname of broker. Default is automatic port.", metavar="PORT")
-        parser.add_option("--pip", dest="pip", default="127.0.0.1",
-                          help="IP/hostname of parent broker. Default is 127.0.0.1.", metavar="IP")
-        parser.add_option("--pport", dest="pport", default=9559,
-                          help="port of parent broker. Default is 9559.", metavar="PORT")
-
-        (options, args) = parser.parse_args()
-        self.ip = options.ip
-        self.port = int(options.port)
-        self.pip = options.pip
-        self.pport = int(options.pport)
-        self.moduleName = moduleName
-
-        self.init_almodule()
-
-        # ROS initialization:
-        rospy.init_node('naoqi_externalCollisionAvoidance')
-
+class NaoqiExternalCollisionAvoidance(NaoqiNode):
+    def __init__(self):
+        NaoqiNode.__init__(self, 'naoqi_externalCollisionAvoidance')
+        self.connectNaoQi()
+        
         # init. messages:
         self.moveFailed = String()
-        
-        self.setOrthogonalSecurityDistanceSrv = rospy.Service("naoqi_externalCollisionAvoidance/orthogonal_distance", OrthogonalSecurityDistance, self.handleOrthogonalSecurityDistanceSrv)
-        self.setTangentialSecurityDistanceSrv = rospy.Service("naoqi_externalCollisionAvoidance/tangential_distance", TangentialSecurityDistance, self.handleTangentialSecurityDistanceSrv)
-        self.moveFailedPub = rospy.Publisher("move_failed", String, queue_size=10)
-        
-        self.subscribe()
+        self.previousMoveFailedInfomation = ""
+        self.setOrthogonalSecurityDistanceSrv = rospy.Service("set_orthogonal_distance", OrthogonalSecurityDistance, self.handleSetOrthogonalSecurityDistanceSrv)
+        self.setTangentialSecurityDistanceSrv = rospy.Service("set_tangential_distance", TangentialSecurityDistance, self.handleSetTangentialSecurityDistanceSrv)
+        self.getMoveFailedInformationSrv = rospy.Service("move_failed_information", Empty, self.handleMoveFailedInformationSrv)
+        self.setOrthogonalSecurityDistanceSrv = rospy.Service("get_orthogonal_distance", Empty, self.handleGetOrthogonalSecurityDistanceSrv)
+        self.setTangentialSecurityDistanceSrv = rospy.Service("get_tangential_distance", Empty, self.handleGetTangentialSecurityDistanceSrv)
+        self.setExternalCollisionProtectionEnabledSrv = rospy.Service("set_external_collision_protection_status", SetExternalCollisionProtectionEnabled, self.handleSetExternalCollisionProtectionEnabled)
+        self.getExternalCollisionProtectionEnabledSrv = rospy.Service("get_external_collision_protection_status", GetExternalCollisionProtectionEnabled, self.handleGetExternalCollisionProtectionEnabled)
+        rospy.loginfo("naoqi_externalCollisionAvoidance initialized")
 
-        rospy.loginfo("nao_externalCollisionAvoidance initialized")
-
-    def init_almodule(self):
-        # before we can instantiate an ALModule, an ALBroker has to be created
+    def connectNaoQi(self):
         rospy.loginfo("Connecting to NaoQi at %s:%d", self.pip, self.pport)
-        try:
-            self.broker = ALBroker("%sBroker" % self.moduleName, self.ip, self.port, self.pip, self.pport)
-        except RuntimeError,e:
-            print("Could not connect to NaoQi's main broker")
+        self.memProxy = self.get_proxy("ALMemory")
+        self.motionProxy = self.get_proxy("ALMotion")
+        if self.memProxy is None or self.motionProxy is None:
             exit(1)
-        ALModule.__init__(self, self.moduleName)
-
-        self.memProxy = ALProxy("ALMemory", self.pip, self.pport)
-        # TODO: check self.memProxy.version() for > 1.6
-        if self.memProxy is None:
-            rospy.logerror("Could not get a proxy to ALMemory on %s:%d", self.pip, self.pport)
-            exit(1)
-        self.motionProxy = ALProxy("ALMotion", self.pip, self.pport)
-
-
-    def shutdown(self):
-        self.unsubscribe()
-        # Shutting down broker seems to be not necessary any more
-        # try:
-        #     self.broker.shutdown()
-        # except RuntimeError,e:
-        #     rospy.logwarn("Could not shut down Python Broker: %s", e)
-
-
-    def subscribe(self):
-        self.memProxy.subscribeToEvent("ALMotion/MoveFailed", self.moduleName, "onMoveFailed")
         
+    def handleSetOrthogonalSecurityDistanceSrv(self, req):
+        try:
+            if (req.orthogonal_distance > 0.001 or req.orthogonal_distance == 0.001):
+                self.motionProxy.setOrthogonalSecurityDistance(req.orthogonal_distance.data)
+                rospy.loginfo("Orthogonal security distance is set to " + str(req.orthogonal_distance.data))
+                return OrthogonalSecurityDistanceResponse()
+            else:
+                rospy.loginfo("Orthogonal security distance should be 0.001, or more than 0.001")
+                return OrthogonalSecurityDistanceResponse()
+        except RuntimeError, e:
+            rospy.logerr("Exception caught:\n%s", e)
+            return None
+        
+    def handleSetTangentialSecurityDistanceSrv(self, req):
+        try:
+            if (req.tangential_distance > 0.001 or req.tangential_distance == 0.001):
+                self.motionProxy.setTangentialSecurityDistance(req.tangential_distance.data)
+                rospy.loginfo("Tangential security distance is set to " + str(req.tangential_distance.data))
+                return TangentialSecurityDistanceResponse()
+            else:
+                rospy.loginfo("Tangential distance should be 0.001, or more than 0.001")
+                return TangentialSecurityDistanceResponse()
+        except RuntimeError, e:
+            rospy.logerr("Exception caught:\n%s", e)
+            return None
+        
+    def handleGetOrthogonalSecurityDistanceSrv(self, req):
+        try:
+            rospy.loginfo("Current Orthogonal Security Distance: " + str(self.motionProxy.getOrthogonalSecurityDistance()))
+            return EmptyResponse()
+        except RuntimeError, e:
+            rospy.logerr("Exception caught:\n%s", e)
+            return None
 
-    def unsubscribe(self):
-        self.memProxy.unsubscribeToEvent("ALMotion/MoveFailed", self.moduleName)
+    def handleGetTangentialSecurityDistanceSrv(self, req):
+        try:
+            rospy.loginfo("Current Tangential Security Distance: " + str(self.motionProxy.getTangentialSecurityDistance()))
+            return EmptyResponse()
+        except RuntimeError, e:
+            rospy.logerr("Exception caught:\n%s", e)
+            return None
 
-    def handleOrthogonalSecurityDistanceSrv(self, req):
-        if (req.orthogonal_distance < 0.001 or req.orthogonal_distance == 0.001):
-            return EmptyResponse
-        self.motionProxy.setOrthogonalSecurityDistance(req.orthogonal_distance.data)
-        return EmptyResponse
+    def handleMoveFailedInformationSrv(self, req):
+        if self.memProxy.getData("ALMotion/MoveFailed") != self.previousMoveFailedInfomation:
+            moveFailedData = self.memProxy.getData("ALMotion/MoveFailed")
+            self.previousMoveFailedInformation = moveFailedData
+            moveFailedMessage = "I CANNOT MOVE\n Cause of move failed: " + moveFailedData[0]
+            if moveFailedData[1] == 0:
+                moveFailedMessage  += ", Status: move not started" 
+            if moveFailedData[1] == 1:
+                moveFailedMessage += ", Status: move started but stopped" 
+            moveFailedMessage += ", Obstacle position: "+ str(moveFailedData[2])
+            rospy.loginfo(moveFailedMessage)
+            return EmptyResponse()
 
-    def handleTangentialSecurityDistanceSrv(self, req):
-        if (req.tangential_distance < 0.001 or req.tangential_distance == 0.001):
-            return EmptyResponse
-        self.motionProxy.setTangentialSecurityDistance(req.tangential_distance.data)
-        return EmptyResponse
+    def handleSetExternalCollisionProtectionEnabled(self, req):
+        try:
+            self.motionProxy.setExternalCollisionProtectionEnabled(req.name.data, req.status)
+            if self.motionProxy.getExternalCollisionProtectionEnabled(req.name.data)== True: 
+                rospy.loginfo("Current External Collision Protection Status of " + req.name.data + ": Enabled")
+            else:
+                rospy.loginfo("Current External Collision Protection Status of " + req.name.data + ": Disabled")
+            if (req.name.data == "All" or req.name.data == "Move") and req.status == False:
+                rospy.loginfo("CAUTION: YOU DEACTIVATED SAFETY REFLEXES. BE CAREFUL TO THE SAFETY OF THE ROBOT AND PEOPLE.")
+            return SetExternalCollisionProtectionEnabledResponse()
+        except RuntimeError, e:
+            rospy.logerr("Exception caught:\n%s", e)
+            return None
 
-    def onMoveFailed(self, strVarName, value, strMessage):
-        "Called when ALMotion/MoveFailed event is raised in ALMemory"
-        publish_message = "Cause of move failed: " + value[0]
-        if value[1] == 0:
-            publish_message += ", Status: move not started" 
-        if value[1] == 1:
-            publish_message += ", Status: move started but stopped" 
-    
-        publish_message += ", Obstacle position: "+ str(value[2])
-        self.moveFailed.data = publish_message;
-        self.moveFailedPub.publish(self.moveFailed)
-        rospy.logdebug("move failed: name=%s, value=%s, message=%s.", strVarName, value, strMessage);
+    def handleGetExternalCollisionProtectionEnabled(self, req):
+        try:
+            if self.motionProxy.getExternalCollisionProtectionEnabled(req.name.data)== True: 
+                rospy.loginfo("Current External Collision Protection Status of " + req.name.data + ": Enabled")
+            else:
+                rospy.loginfo("Current External Collision Protection Status of " + req.name.data + ": Disabled")
+            return GetExternalCollisionProtectionEnabledResponse()
+        except RuntimeError, e:
+            rospy.logerr("Exception caught:\n%s", e)
+            return None
 
+    def run(self):
+        while self.is_looping():
+            try:
+                pass
+            except RuntimeError, e:
+                print "Error accessing ALMemory and ALMotion, exiting...\n"
+                print e
+                rospy.signal_shutdown("No NaoQI available anymore")
 
 if __name__ == '__main__':
-    ROSNaoqiExternalCollisionAvoidanceModule = NaoqiExternalCollisionAvoidance("ROSNaoqiExternalCollisionAvoidanceModule")
-
+    externalCollisionAvoidance = NaoqiExternalCollisionAvoidance()
+    externalCollisionAvoidance.start()
     rospy.spin()
-
-    rospy.loginfo("Stopping naoqi_externalCollisionAvoidance ...")
-    ROSNaoqiExternalCollisionAvoidanceModule.shutdown();
-    rospy.loginfo("naoqi_externalCollisionAvoidance stopped.")
-    exit(0)

--- a/naoqi_apps/nodes/naoqi_externalCollisionAvoidance.py
+++ b/naoqi_apps/nodes/naoqi_externalCollisionAvoidance.py
@@ -124,10 +124,10 @@ class NaoqiExternalCollisionAvoidance(NaoqiNode):
             if req.name.data == 4:
                 target_name = "RArm"
             res = SetExternalCollisionProtectionEnabledResponse()
-            res.status = False
+            res.success = False
             if self.motionProxy.setExternalCollisionProtectionEnabled(target_name, req.status) == None:
-                res.status = True
-                if self.motionProxy.getExternalCollisionProtectionEnabled(target_name)== True:
+                res.success = True
+                if req.status == True:
                     rospy.loginfo("Current External Collision Protection Status of " + target_name + ": Enabled")
                 else:
                     rospy.loginfo("Current External Collision Protection Status of " + target_name + ": Disabled")

--- a/naoqi_apps/nodes/naoqi_externalCollisionAvoidance.py
+++ b/naoqi_apps/nodes/naoqi_externalCollisionAvoidance.py
@@ -113,13 +113,23 @@ class NaoqiExternalCollisionAvoidance(NaoqiNode):
 
     def handleSetExternalCollisionProtectionEnabled(self, req):
         try:
-            self.motionProxy.setExternalCollisionProtectionEnabled(req.name.data, req.status)
-            if self.motionProxy.getExternalCollisionProtectionEnabled(req.name.data)== True: 
-                rospy.loginfo("Current External Collision Protection Status of " + req.name.data + ": Enabled")
+            if req.name.number == 0:
+                target_name = "All"
+            if req.name.number == 1:
+                target_name = "Move"
+            if req.name.number == 2:
+                target_name = "Arms"
+            if req.name.number == 3:
+                target_name = "LArm"
+            if req.name.number == 4:
+                target_name = "RArm"
+            self.motionProxy.setExternalCollisionProtectionEnabled(target_name, req.status)
+            if self.motionProxy.getExternalCollisionProtectionEnabled(target_name)== True:
+                rospy.loginfo("Current External Collision Protection Status of " + target_name + ": Enabled")
             else:
-                rospy.loginfo("Current External Collision Protection Status of " + req.name.data + ": Disabled")
-            if (req.name.data == "All" or req.name.data == "Move") and req.status == False:
-                rospy.loginfo("CAUTION: YOU DEACTIVATED SAFETY REFLEXES. BE CAREFUL TO THE SAFETY OF THE ROBOT AND PEOPLE.")
+                rospy.loginfo("Current External Collision Protection Status of " + target_name + ": Disabled")
+                if (target_name == "All" or target_name == "Move") and req.status == False:
+                    rospy.loginfo("CAUTION: YOU DEACTIVATED SAFETY REFLEXES. BE CAREFUL TO THE SAFETY OF THE ROBOT AND PEOPLE.")
             return SetExternalCollisionProtectionEnabledResponse()
         except RuntimeError, e:
             rospy.logerr("Exception caught:\n%s", e)
@@ -127,10 +137,20 @@ class NaoqiExternalCollisionAvoidance(NaoqiNode):
 
     def handleGetExternalCollisionProtectionEnabled(self, req):
         try:
-            if self.motionProxy.getExternalCollisionProtectionEnabled(req.name.data)== True: 
-                rospy.loginfo("Current External Collision Protection Status of " + req.name.data + ": Enabled")
+            if req.name.number == 0:
+                target_name = "All"
+            if req.name.number == 1:
+                target_name = "Move"
+            if req.name.number == 2:
+                target_name = "Arms"
+            if req.name.number == 3:
+                target_name = "LArm"
+            if req.name.number == 4:
+                target_name = "RArm"
+            if self.motionProxy.getExternalCollisionProtectionEnabled(target_name)== True: 
+                rospy.loginfo("Current External Collision Protection Status of " + target_name + ": Enabled")
             else:
-                rospy.loginfo("Current External Collision Protection Status of " + req.name.data + ": Disabled")
+                rospy.loginfo("Current External Collision Protection Status of " + target_name + ": Disabled")
             return GetExternalCollisionProtectionEnabledResponse()
         except RuntimeError, e:
             rospy.logerr("Exception caught:\n%s", e)


### PR DESCRIPTION
I added two services for ```setOrthogonalSecurityDistance```and ```setTangentialSecurityDistance``` to extend pepper's move range, and one publisher for ```/move_failed``` event.
It requires two new services, which I will send another pull request for ```naoqi_bridge_msgs```.

I am still uncertain about the minimum distance which can be set to these two functions (I thought 0.001, but it might be wrong. I will modify it as soon as possible.).
In addition, I am not sure whether node name and program name are proper or not.

For everything, if there is any problem, please let me know. I am very sorry for troubling you.
 