### PR TITLE
Avoid an error if other arguments are given than the expected ones

### DIFF
--- a/naoqi_driver_py/src/naoqi_driver/naoqi_node.py
+++ b/naoqi_driver_py/src/naoqi_driver/naoqi_node.py
@@ -83,7 +83,7 @@ class NaoqiNode(Thread):
                           help="port of parent broker. Default is 9559.", metavar="PORT")
 
         import sys
-        args = parser.parse_args(args=rospy.myargv(argv=sys.argv)[1:])
+        args, unknown = parser.parse_known_args(args=rospy.myargv(argv=sys.argv)[1:])
         self.pip = args.pip
         self.pport = args.pport
 


### PR DESCRIPTION
If ones want to include a NaoqiNode in another script, requiring more arguments on the command line, the parser will fail. 

This new version allows to have unknown arguments
