### PR TITLE
[naoqi_apps] add naoqi_tablet node/launch for showImage

### DIFF
--- a/naoqi_apps/launch/tablet.launch
+++ b/naoqi_apps/launch/tablet.launch
@@ -1,0 +1,13 @@
+<launch>
+    <!--
+    This pushes the local PYTHONPATH into the launch file, so that the NaoQI API is found.
+    You need to add the Nao's API dir to your PYTHONPATH so that the modules are found.
+  -->
+  <env name="PYTHONPATH" value="$(env PYTHONPATH)" />
+
+  <arg name="nao_ip" default="$(optenv NAO_IP 127.0.0.1)" />
+  <arg name="nao_port" default="$(optenv NAO_PORT 9559)" />
+
+  <node pkg="naoqi_apps" type="naoqi_tablet.py" name="naoqi_tablet" required="true" args="--pip=$(arg nao_ip) --pport=$(arg nao_port)" output="screen" />
+</launch>
+

--- a/naoqi_apps/nodes/naoqi_tablet.py
+++ b/naoqi_apps/nodes/naoqi_tablet.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+
+#                                                                             
+#  Copyright 2015 Aldebaran                                                   
+#                                                                             
+#  Licensed under the Apache License, Version 2.0 (the "License");            
+#  you may not use this file except in compliance with the License.           
+#  You may obtain a copy of the License at                                    
+#                                                                             
+#      http://www.apache.org/licenses/LICENSE-2.0                             
+#                                                                             
+#  Unless required by applicable law or agreed to in writing, software        
+#  distributed under the License is distributed on an "AS IS" BASIS,          
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   
+#  See the License for the specific language governing permissions and        
+#  limitations under the License.                                             
+#                                                                             
+# 
+import rospy
+from naoqi_driver.naoqi_node import NaoqiNode
+from std_srvs.srv import (
+    EmptyResponse,
+    Empty,)
+from naoqi_bridge_msgs.srv import ( 
+    ShowImageResponse,
+    ShowImage,)
+
+class NaoqiTablet(NaoqiNode):
+    def __init__(self):
+        NaoqiNode.__init__(self, 'naoqi_tablet')
+        self.connectNaoQi()
+        
+        self.image_path = ""
+        self.showImageSrv = rospy.Service("show_image", ShowImage, self.handleShowImageSrv)
+        self.hideImageSrv = rospy.Service("hide_image", Empty, self.handleHideImageSrv)
+        rospy.loginfo("naoqi_tablet initialized")
+    
+    def connectNaoQi(self):
+        rospy.loginfo("Connecting to NaoQi at %s:%d", self.pip, self.pport)
+        self.tabletProxy = self.get_proxy("ALTabletService")
+        if self.tabletProxy is None:
+            exit(1)
+        
+    def handleShowImageSrv(self, req):
+        try:
+            self.image_path = "http://198.18.0.1/apps/img/" + str(req.file_name.data)
+            rospy.loginfo(self.image_path)
+            if self.tabletProxy.showImage(self.image_path) == True:
+                rospy.loginfo("Ok, I'll show you " + str(req.file_name.data) + " !")
+            else:
+                rospy.loginfo("Please confirm the file name and " + str(req.file_name.data) + " really exists under /home/nao/.local/share/PackageManager/apps/img/html.")
+            self.image_path = ""
+            return ShowImageResponse()
+        except RuntimeError, e:
+            rospy.logerr("Exception caught:\n%s", e)
+            return None
+        
+    def handleHideImageSrv(self, req):
+        try:
+            self.tabletProxy.hideImage()
+            rospy.loginfo("I'll hide the picture on the tablet.")
+            return EmptyResponse()
+        except RuntimeError, e:
+            rospy.logerr("Exception caught:\n%s", e)
+            return None
+        
+    def run(self):
+        while self.is_looping():
+            try:
+                pass
+            except RuntimeError, e:
+                print "Error accessing ALMemory and ALMotion, exiting...\n"
+                print e
+                rospy.signal_shutdown("No NaoQI available anymore")
+
+if __name__ == '__main__':
+    tablet = NaoqiTablet()
+    tablet.start()
+    rospy.spin()

--- a/naoqi_apps/nodes/naoqi_tablet.py
+++ b/naoqi_apps/nodes/naoqi_tablet.py
@@ -22,12 +22,8 @@ from std_srvs.srv import (
     EmptyResponse,
     Empty,)
 from naoqi_bridge_msgs.srv import ( 
-    ShowImageResponse,
-    ShowImage,
-    ShowAppResponse,
-    ShowApp,
-    ShowWebviewResponse,
-    ShowWebview,
+    ShowResourceResponse,
+    ShowResource,
     SetFolderPathResponse,
     SetFolderPath,
     GetFolderPathResponse,
@@ -40,10 +36,10 @@ class NaoqiTablet(NaoqiNode):
         
         self.image_path = ""
         self.image_folder = "img/"
-        self.showImageSrv = rospy.Service("show_image", ShowImage, self.handleShowImageSrv)
+        self.showImageSrv = rospy.Service("show_image", ShowResource, self.handleShowImageSrv)
         self.hideImageSrv = rospy.Service("hide_image", Empty, self.handleHideImageSrv)
-        self.showAppSrv = rospy.Service("show_app", ShowApp, self.handleShowAppSrv)
-        self.showWebViewSrv = rospy.Service("show_webview", ShowWebview, self.handleShowWebviewSrv)
+        self.showAppSrv = rospy.Service("show_app", ShowResource, self.handleShowAppSrv)
+        self.showWebViewSrv = rospy.Service("show_webview", ShowResource, self.handleShowWebviewSrv)
         self.setImagePathSrv = rospy.Service("set_show_image_folder_path", SetFolderPath, self.handleSetFolderPathSrv)
         self.getImagePathSrv = rospy.Service("get_show_image_folder_path", GetFolderPath, self.handleGetFolderPathSrv)
         rospy.loginfo("naoqi_tablet initialized")
@@ -56,15 +52,15 @@ class NaoqiTablet(NaoqiNode):
         
     def handleShowImageSrv(self, req):
         try:
-            self.image_path = "http://198.18.0.1/apps/"+ self.image_folder + str(req.file_name.data)
-            res = ShowImageResponse()
+            self.image_path = "http://198.18.0.1/apps/"+ self.image_folder + str(req.name.data)
+            res = ShowResourceResponse()
             if self.tabletProxy.showImage(self.image_path) == True:
-                rospy.loginfo("Ok, I'll show you " + str(req.file_name.data) + " !")
-                res.status.data = True
+                rospy.loginfo("Ok, I'll show you " + str(req.name.data) + " !")
+                res.success.data = True
                
             else:
-                rospy.loginfo("Please confirm the file name and " + str(req.file_name.data) + " really exists under /home/nao/.local/share/PackageManager/apps/" + self.image_folder + "html.")
-                res.status.data = False
+                rospy.loginfo("Please confirm the file name and " + str(req.name.data) + " really exists under /home/nao/.local/share/PackageManager/apps/" + self.image_folder + "html.")
+                res.success.data = False
             self.image_path = ""
             return res
         except RuntimeError, e:
@@ -82,30 +78,30 @@ class NaoqiTablet(NaoqiNode):
 
     def handleShowAppSrv(self, req):
         try:
-            self.tabletProxy.loadApplication(req.app_name.data)
-            res = ShowAppResponse()
+            self.tabletProxy.loadApplication(req.name.data)
+            res = ShowResourceResponse()
             if self.tabletProxy.showWebview() == True:
-                rospy.loginfo("Ok, I'll show you " + req.app_name.data + " app !")
-                res.status.data = True
+                rospy.loginfo("Ok, I'll show you " + req.name.data + " app !")
+                res.success.data = True
                
             else:
-                rospy.loginfo("Please confirm the app name " + req.app_name.data + "really exists. In addtion, be sure that the index.html must be in a folder html in the behavior folder.")
-                res.status.data = False
+                rospy.loginfo("Please confirm the app name " + req.name.data + "really exists. In addtion, be sure that the index.html must be in a folder html in the behavior folder.")
+                res.success.data = False
             return res
         except RuntimeError, e:
             rospy.logerr("Exception caught:\n%s", e)
             return None
     def handleShowWebviewSrv(self, req):
         try:
-            self.tabletProxy.loadUrl(req.url.data)
-            res = ShowWebviewResponse()
+            self.tabletProxy.loadUrl(req.name.data)
+            res = ShowResourceResponse()
             if self.tabletProxy.showWebview() == True:
-                rospy.loginfo("Ok, I'll show you " + str(req.url.data) + " !")
-                res.status.data = True
+                rospy.loginfo("Ok, I'll show you " + str(req.name.data) + " !")
+                res.success.data = True
                
             else:
-                rospy.loginfo("Please confirm the url '" + str(req.url.data) + "' really exists.")
-                res.status.data = False
+                rospy.loginfo("Please confirm the url '" + str(req.name.data) + "' really exists.")
+                res.success.data = False
             return res
         except RuntimeError, e:
             rospy.logerr("Exception caught:\n%s", e)

--- a/naoqi_apps/nodes/naoqi_tablet.py
+++ b/naoqi_apps/nodes/naoqi_tablet.py
@@ -44,7 +44,6 @@ class NaoqiTablet(NaoqiNode):
     def handleShowImageSrv(self, req):
         try:
             self.image_path = "http://198.18.0.1/apps/img/" + str(req.file_name.data)
-            rospy.loginfo(self.image_path)
             if self.tabletProxy.showImage(self.image_path) == True:
                 rospy.loginfo("Ok, I'll show you " + str(req.file_name.data) + " !")
             else:

--- a/naoqi_apps/nodes/naoqi_tablet.py
+++ b/naoqi_apps/nodes/naoqi_tablet.py
@@ -85,7 +85,7 @@ class NaoqiTablet(NaoqiNode):
             self.tabletProxy.loadApplication(req.app_name.data)
             res = ShowAppResponse()
             if self.tabletProxy.showWebview() == True:
-                rospy.loginfo("Ok, I'll show you " + req.app_name.data + "app !")
+                rospy.loginfo("Ok, I'll show you " + req.app_name.data + " app !")
                 res.status.data = True
                
             else:

--- a/naoqi_apps/nodes/naoqi_tablet.py
+++ b/naoqi_apps/nodes/naoqi_tablet.py
@@ -33,6 +33,7 @@ class NaoqiTablet(NaoqiNode):
         self.image_path = ""
         self.showImageSrv = rospy.Service("show_image", ShowImage, self.handleShowImageSrv)
         self.hideImageSrv = rospy.Service("hide_image", Empty, self.handleHideImageSrv)
+        self.showWebViewSrv = rospy.Service("show_webview", ShowImage, self.handleShowWebviewSrv)
         rospy.loginfo("naoqi_tablet initialized")
     
     def connectNaoQi(self):
@@ -67,6 +68,23 @@ class NaoqiTablet(NaoqiNode):
             rospy.logerr("Exception caught:\n%s", e)
             return None
         
+    def handleShowWebviewSrv(self, req):
+        try:
+            self.image_path = "http://198.18.0.1/apps/img/" + str(req.file_name.data)
+            res = ShowImageResponse()
+            if self.tabletProxy.showWebview(self.image_path) == True:
+                rospy.loginfo("Ok, I'll show you " + str(req.file_name.data) + " !")
+                res.status.data = True
+               
+            else:
+                rospy.loginfo("Please confirm the file name and " + str(req.file_name.data) + " really exists under /home/nao/.local/share/PackageManager/apps/img/html.")
+                res.status.data = False
+            self.image_path = ""
+            return res
+        except RuntimeError, e:
+            rospy.logerr("Exception caught:\n%s", e)
+            return None
+            
     def run(self):
         while self.is_looping():
             try:

--- a/naoqi_apps/nodes/naoqi_tablet.py
+++ b/naoqi_apps/nodes/naoqi_tablet.py
@@ -44,12 +44,16 @@ class NaoqiTablet(NaoqiNode):
     def handleShowImageSrv(self, req):
         try:
             self.image_path = "http://198.18.0.1/apps/img/" + str(req.file_name.data)
+            res = ShowImageResponse()
             if self.tabletProxy.showImage(self.image_path) == True:
                 rospy.loginfo("Ok, I'll show you " + str(req.file_name.data) + " !")
+                res.status.data = True
+               
             else:
                 rospy.loginfo("Please confirm the file name and " + str(req.file_name.data) + " really exists under /home/nao/.local/share/PackageManager/apps/img/html.")
+                res.status.data = False
             self.image_path = ""
-            return ShowImageResponse()
+            return res
         except RuntimeError, e:
             rospy.logerr("Exception caught:\n%s", e)
             return None

--- a/naoqi_apps/nodes/naoqi_tablet.py
+++ b/naoqi_apps/nodes/naoqi_tablet.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #                                                                             
-#  Copyright 2015 Aldebaran                                                   
+#  Copyright 2018 Aldebaran
 #                                                                             
 #  Licensed under the Apache License, Version 2.0 (the "License");            
 #  you may not use this file except in compliance with the License.           
@@ -20,48 +20,56 @@ import rospy
 from naoqi_driver.naoqi_node import NaoqiNode
 from std_srvs.srv import (
     EmptyResponse,
-    Empty,)
+    Empty,
+    TriggerResponse,
+    Trigger)
 from naoqi_bridge_msgs.srv import ( 
-    ShowResourceResponse,
-    ShowResource,
-    SetFolderPathResponse,
-    SetFolderPath,
-    GetFolderPathResponse,
-    GetFolderPath)
+    SetStringResponse,
+    SetString,
+    GetStringResponse,
+    GetString,
+    ConfigureWifiResponse,
+    ConfigureWifi)
 
 class NaoqiTablet(NaoqiNode):
     def __init__(self):
         NaoqiNode.__init__(self, 'naoqi_tablet')
         self.connectNaoQi()
-        
-        self.image_path = ""
         self.image_folder = "img/"
-        self.showImageSrv = rospy.Service("show_image", ShowResource, self.handleShowImageSrv)
+        self.showImageSrv = rospy.Service("show_image", SetString, self.handleShowImageSrv)
         self.hideImageSrv = rospy.Service("hide_image", Empty, self.handleHideImageSrv)
-        self.showAppSrv = rospy.Service("show_app", ShowResource, self.handleShowAppSrv)
-        self.showWebViewSrv = rospy.Service("show_webview", ShowResource, self.handleShowWebviewSrv)
-        self.setImagePathSrv = rospy.Service("set_show_image_folder_path", SetFolderPath, self.handleSetFolderPathSrv)
-        self.getImagePathSrv = rospy.Service("get_show_image_folder_path", GetFolderPath, self.handleGetFolderPathSrv)
+        self.showAppSrv = rospy.Service("show_app", SetString, self.handleShowAppSrv)
+        self.showWebViewSrv = rospy.Service("show_webview", SetString, self.handleShowWebviewSrv)
+        self.setImagePathSrv = rospy.Service("set_show_image_folder_path", SetString, self.handleSetFolderPathSrv)
+        self.getImagePathSrv = rospy.Service("get_show_image_folder_path", GetString, self.handleGetFolderPathSrv)
+        self.configureWifiSrv = rospy.Service("configure_wifi", ConfigureWifi, self.handleConfigureWifiSrv)
+        self.connectWifiSrv = rospy.Service("connect_wifi", SetString, self.handleConnectWifiSrv)
+        self.disconnectWifiSrv = rospy.Service("disconnect_wifi", Trigger, self.handleDisconnectWifiSrv)
+        self.enableWifiSrv = rospy.Service("enable_wifi", Empty, self.handleEnableWifiSrv)
+        self.disableWifiSrv = rospy.Service("disable_wifi", Empty, self.handleDisableWifiSrv)
+        self.forgetWifiSrv = rospy.Service("forget_wifi", SetString, self.handleForgetWifiSrv)
+        self.getWifiStatusSrv = rospy.Service("get_wifi_status", GetString, self.handleGetWifiStatusSrv)
         rospy.loginfo("naoqi_tablet initialized")
     
     def connectNaoQi(self):
         rospy.loginfo("Connecting to NaoQi at %s:%d", self.pip, self.pport)
         self.tabletProxy = self.get_proxy("ALTabletService")
         if self.tabletProxy is None:
+            rospy.logerr("Could not get a proxy to ALTabletService")
+            rospy.logerr("Please make sure that your robot has a tablet.")
             exit(1)
-        
+
     def handleShowImageSrv(self, req):
         try:
-            self.image_path = "http://198.18.0.1/apps/"+ self.image_folder + str(req.name.data)
-            res = ShowResourceResponse()
-            if self.tabletProxy.showImage(self.image_path) == True:
-                rospy.loginfo("Ok, I'll show you " + str(req.name.data) + " !")
-                res.success.data = True
+            image_path = "http://198.18.0.1/apps/"+ self.image_folder + str(req.data)
+            res = SetStringResponse()
+            if self.tabletProxy.showImage(image_path) == True:
+                rospy.loginfo("Showing image: " + str(req.data))
+                res.success = True
                
             else:
-                rospy.loginfo("Please confirm the file name and " + str(req.name.data) + " really exists under /home/nao/.local/share/PackageManager/apps/" + self.image_folder + "html.")
+                rospy.loginfo("Please confirm the file name and " + str(req.data) + " really exists under /home/nao/.local/share/PackageManager/apps/" + self.image_folder + "html.")
                 res.success.data = False
-            self.image_path = ""
             return res
         except RuntimeError, e:
             rospy.logerr("Exception caught:\n%s", e)
@@ -70,7 +78,7 @@ class NaoqiTablet(NaoqiNode):
     def handleHideImageSrv(self, req):
         try:
             self.tabletProxy.hideImage()
-            rospy.loginfo("I'll hide the picture on the tablet.")
+            rospy.loginfo("Reset image on the tablet")
             return EmptyResponse()
         except RuntimeError, e:
             rospy.logerr("Exception caught:\n%s", e)
@@ -78,67 +86,125 @@ class NaoqiTablet(NaoqiNode):
 
     def handleShowAppSrv(self, req):
         try:
-            self.tabletProxy.loadApplication(req.name.data)
-            res = ShowResourceResponse()
-            if self.tabletProxy.showWebview() == True:
-                rospy.loginfo("Ok, I'll show you " + req.name.data + " app !")
-                res.success.data = True
-               
+            res = SetStringResponse()
+            res.success = False
+            if self.tabletProxy.loadApplication(req.data):
+                if self.tabletProxy.showWebview():
+                    rospy.loginfo("Showing app: " + str(req.data))
+                    res.success = True
+                else:
+                    rospy.loginfo("Showing webview failed")
             else:
-                rospy.loginfo("Please confirm the app name " + req.name.data + "really exists. In addtion, be sure that the index.html must be in a folder html in the behavior folder.")
-                res.success.data = False
+                rospy.loginfo("Please confirm your app name: " + req.data + "really exists.")
+                rospy.loginfo("In addtion, be sure that an index.html should be in a html folder in an app folder. (ex: /home/nao/.local/share/PackageManager/apps/<app>/html/index.html)")
             return res
         except RuntimeError, e:
             rospy.logerr("Exception caught:\n%s", e)
             return None
+
     def handleShowWebviewSrv(self, req):
         try:
-            self.tabletProxy.loadUrl(req.name.data)
-            res = ShowResourceResponse()
-            if self.tabletProxy.showWebview() == True:
-                rospy.loginfo("Ok, I'll show you " + str(req.name.data) + " !")
-                res.success.data = True
-               
+            res = SetStringResponse()
+            res.success = False
+            if self.tabletProxy.showWebview(req.data):
+                rospy.loginfo("Trying to show web page: " + str(req.data))
+                rospy.loginfo("If there is nothing appeared, please confirm the url '" + str(req.data) + "' really exists.")
+                res.success = True
             else:
-                rospy.loginfo("Please confirm the url '" + str(req.name.data) + "' really exists.")
-                res.success.data = False
+                rospy.loginfo("Showing webview failed")
             return res
         except RuntimeError, e:
             rospy.logerr("Exception caught:\n%s", e)
             return None
+
     def handleSetFolderPathSrv(self, req):
+        res = SetStringResponse()
         try:
-            self.image_folder = req.folder_path.data
+            self.image_folder = req.data
             if self.image_folder[0]=="/":
                 self.image_folder = self.image_folder.strip("/")
             if self.image_folder[len(self.image_folder)-1] != "/":
                 self.image_folder += "/"
+            res.success = True
             rospy.loginfo("ALTabletService: ShowImage will show pictures under /home/nao/.local/share/PackageManager/apps/" + self.image_folder + "html/." )
-            return SetFolderPathResponse()
+            return res
         except RuntimeError, e:
             rospy.logerr("Exception caught:\n%s", e)
             return None
     
     def handleGetFolderPathSrv(self, req):
         try:
-            res = GetFolderPathResponse()
-            res.folder_path.data = "/home/nao/.local/share/PackageManager/apps/" + self.image_folder + "html/"
+            res = GetStringResponse()
+            res.data = "/home/nao/.local/share/PackageManager/apps/" + str(self.image_folder) + "html/"
             rospy.loginfo("ALTabletService: ShowImage will show pictures under /home/nao/.local/share/PackageManager/apps/" + self.image_folder + "html.")
             return res
         except RuntimeError, e:
             rospy.logerr("Exception caught:\n%s", e)
             return None
 
-    def run(self):
-        while self.is_looping():
-            try:
-                pass
-            except RuntimeError, e:
-                print "Error accessing ALMemory and ALMotion, exiting...\n"
-                print e
-                rospy.signal_shutdown("No NaoQI available anymore")
+    def handleConfigureWifiSrv(self, req):
+        try:
+            res = ConfigureWifiResponse()
+            res.success = self.tabletProxy.configureWifi(req.security, req.ssid, req.key)
+            return res
+        except RuntimeError, e:
+            rospy.logerr("Exception caught:\n%s", e)
+            return None
+
+    def handleConnectWifiSrv(self, req):
+        try:
+            res = SetStringResponse()
+            res.success = self.tabletProxy.connectWifi(req.data)
+            return res
+        except RuntimeError, e:
+            rospy.logerr("Exception caught:\n%s", e)
+            return None
+
+    def handleDisconnectWifiSrv(self, req):
+        try:
+            res = TriggerResponse()
+            res.success = self.tabletProxy.disconnectWifi()
+            return res
+        except RuntimeError, e:
+            rospy.logerr("Exception caught:\n%s", e)
+            return None
+
+    def handleEnableWifiSrv(self, req):
+        try:
+            res = EmptyResponse()
+            self.tabletProxy.enableWifi()
+            return res
+        except RuntimeError, e:
+            rospy.logerr("Exception caught:\n%s", e)
+            return None
+
+    def handleDisableWifiSrv(self, req):
+        try:
+            res = EmptyResponse()
+            self.tabletProxy.disableWifi()
+            return res
+        except RuntimeError, e:
+            rospy.logerr("Exception caught:\n%s", e)
+            return None
+
+    def handleForgetWifiSrv(self, req):
+        try:
+            res = SetStringResponse()
+            res.success = self.tabletProxy.forgetWifi(req.data)
+            return res
+        except RuntimeError, e:
+            rospy.logerr("Exception caught:\n%s", e)
+            return None
+
+    def handleGetWifiStatusSrv(self, req):
+        try:
+            res = GetStringResponse()
+            res.data = self.tabletProxy.getWifiStatus()
+            return res
+        except RuntimeError, e:
+            rospy.logerr("Exception caught:\n%s", e)
+            return None
 
 if __name__ == '__main__':
     tablet = NaoqiTablet()
-    tablet.start()
     rospy.spin()


### PR DESCRIPTION
I made ros service for using `showImage/hideImage` in ALTabletService. 
In the future, I'd like to use this program and `TakePicture` function in ALPhotoCapture.

At first I tried `ShowImage` by choregraphe, and python sample code in documentation inside Pepper, and I found that in order to use this function in a local PC, 
1. preparing the folder to put pictures in advance 
    under `/home/nao/.local/share/PackageManager/apps/`, and 
2. the tablet connected to wifi
are required.

Then, I confirmed this program 
1. by adding img/html folder under `/home/nao/.local/share/PackageManager/apps/img/html/` inside Pepper, 
2. connecting wifi by using `qicli call ALTabletService.configureWifi security ssid key`, and
3. executing `roslaunch naoqi_apps tablet.launch` and 

```
rosservice call /show_image "file_name:
  data: 'cute_pepper.jpg'" 
```

in a local PC. ROS version is indigo, Naoqi version is 2.4.2.26.
It returned `[INFO] [WallTime: 1456128249.651241] Ok, I'll show you cute_pepper.jpg !` and the picture appeared in the tablet.

What I did in order to put a picture in a robot is as follows:
1. ssh nao@ < pepper ip >
2. cd /home/nao/.local/share/PackageManager/apps/
3. mkdir img
4. cd img & mkdir html
5. sending a picture under /home/nao/.local/share/PackageManager/apps/img/html/

I am very sorry to bother you.
If there is any problem, please let me know.
