### PR TITLE
[naoqi_pose] add life/getState service

### DIFF
--- a/naoqi_pose/nodes/pose_controller.py
+++ b/naoqi_pose/nodes/pose_controller.py
@@ -45,6 +45,9 @@ from naoqi_bridge_msgs.msg import(
     BodyPoseWithSpeedAction,
     BodyPoseWithSpeedGoal,
     BodyPoseWithSpeedResult)
+from naoqi_bridge_msgs.srv import(
+    GetAlifeState,
+    GetAlifeStateResponse)
 
 from naoqi_driver.naoqi_node import NaoqiNode
 
@@ -86,7 +89,7 @@ class PoseController(NaoqiNode):
         self.restSrv = rospy.Service("rest", Empty, self.handleRestSrv)
         self.enableLifeSrv = rospy.Service("life/enable", Empty, self.handleLifeSrv)
         self.disableLifeSrv = rospy.Service("life/disable", Empty, self.handleLifeOffSrv)
-        self.getLifeStateSrv = rospy.Service("life/getState", Empty, self.handlegetLifeSrv)
+        self.getLifeStateSrv = rospy.Service("life/getState", GetAlifeState, self.handlegetLifeSrv)
 
 
         #Start simple action servers
@@ -211,10 +214,12 @@ class PoseController(NaoqiNode):
             
     def handlegetLifeSrv(self, req):
         try:
-            rospy.loginfo("Current Life State: " + str(self.lifeProxy.getState()))
-            return EmptyResponse()
+            res = GetAlifeStateResponse()
+            res.status.data = str (self.lifeProxy.getState())
+            rospy.loginfo("Current Life State: " + res.status.data)
+            return res
         except RuntimeError, e:
-            rospy.logerr("Exception while disabling life state:\n%s", e)
+            rospy.logerr("Exception while getting life state:\n%s", e)
             return None
             
     def jointTrajectoryGoalMsgToAL(self, goal):

--- a/naoqi_pose/nodes/pose_controller.py
+++ b/naoqi_pose/nodes/pose_controller.py
@@ -86,6 +86,7 @@ class PoseController(NaoqiNode):
         self.restSrv = rospy.Service("rest", Empty, self.handleRestSrv)
         self.enableLifeSrv = rospy.Service("life/enable", Empty, self.handleLifeSrv)
         self.disableLifeSrv = rospy.Service("life/disable", Empty, self.handleLifeOffSrv)
+        self.getLifeStateSrv = rospy.Service("life/getState", Empty, self.handlegetLifeSrv)
 
 
         #Start simple action servers
@@ -207,7 +208,15 @@ class PoseController(NaoqiNode):
         except RuntimeError, e:
             rospy.logerr("Exception while disabling life state:\n%s", e)
             return None
-
+            
+    def handlegetLifeSrv(self, req):
+        try:
+            rospy.loginfo("Current Life State: " + str(self.lifeProxy.getState()))
+            return EmptyResponse()
+        except RuntimeError, e:
+            rospy.logerr("Exception while disabling life state:\n%s", e)
+            return None
+            
     def jointTrajectoryGoalMsgToAL(self, goal):
         """Helper, convert action goal msg to Aldebraran-style arrays for NaoQI"""
         names = list(goal.trajectory.joint_names)


### PR DESCRIPTION
I added `life/getState` service function.
It requires [naoqi_bridge_msgs pull-request # 8](https://github.com/ros-naoqi/naoqi_bridge_msgs/pull/8).

For example, when I call  `rosservice call /life/getState`, it returns 

```
rosservice call /life/getState 
status: 
  data: interactive
```

If there is any problem, please let me know.
