### PR TITLE
parametrize topic names

### DIFF
--- a/naoqi_driver_py/launch/naoqi_driver.launch
+++ b/naoqi_driver_py/launch/naoqi_driver.launch
@@ -19,6 +19,8 @@
     <node pkg="naoqi_driver_py" type="naoqi_joint_states.py" name="naoqi_joint_states" required="true" args="--pip=$(arg nao_ip) --pport=$(arg nao_port)" />
 
   <!-- start robot agnostic nodes -->
+  <param name="cmd_vel_topic" type="string" value="cmd_vel" />
+  <param name="move_base_simple_topic" type="string" value="move_base_simple/goal" />
   <node pkg="naoqi_driver_py" type="naoqi_moveto.py" name="naoqi_moveto" required="true" args="--pip=$(arg nao_ip) --pport=$(arg nao_port)" output="screen"/>
   <node pkg="naoqi_driver_py" type="naoqi_logger.py" name="nao_logger" args="--pip=$(arg nao_ip) --pport=$(arg nao_port)" />
 </launch>

--- a/naoqi_driver_py/launch/naoqi_driver.launch
+++ b/naoqi_driver_py/launch/naoqi_driver.launch
@@ -19,8 +19,6 @@
     <node pkg="naoqi_driver_py" type="naoqi_joint_states.py" name="naoqi_joint_states" required="true" args="--pip=$(arg nao_ip) --pport=$(arg nao_port)" />
 
   <!-- start robot agnostic nodes -->
-  <param name="cmd_vel_topic" type="string" value="cmd_vel" />
-  <param name="move_base_simple_topic" type="string" value="move_base_simple/goal" />
   <node pkg="naoqi_driver_py" type="naoqi_moveto.py" name="naoqi_moveto" required="true" args="--pip=$(arg nao_ip) --pport=$(arg nao_port)" output="screen"/>
   <node pkg="naoqi_driver_py" type="naoqi_logger.py" name="nao_logger" args="--pip=$(arg nao_ip) --pport=$(arg nao_port)" />
 </launch>

--- a/naoqi_driver_py/src/naoqi_driver/naoqi_moveto.py
+++ b/naoqi_driver_py/src/naoqi_driver/naoqi_moveto.py
@@ -29,15 +29,13 @@ from tf.transformations import euler_from_quaternion
 class MoveToListener(NaoqiNode):
 
     def __init__(self):
-        global cmd_vel_topic, move_base_simple_topic
         NaoqiNode.__init__(self, 'naoqi_moveto_listener')
         self.connectNaoQi()
         self.listener = tf.TransformListener()
-        cmd_vel_topic = rospy.get_param('cmd_vel_topic')
-        move_base_simple_topic = rospy.get_param('move_base_simple_topic')
 
-        self.goal_sub = rospy.Subscriber(move_base_simple_topic, PoseStamped, self.goalCB)
-        self.cvel_sub = rospy.Subscriber(cmd_vel_topic, Twist, self.cvelCB)
+        self.goal_sub = rospy.Subscriber('move_base_simple/goal', PoseStamped, self.goalCB)
+        self.cvel_sub = rospy.Subscriber('cmd_vel', Twist, self.cvelCB)
+
 
     # (re-) connect to NaoQI:
     def connectNaoQi(self):

--- a/naoqi_driver_py/src/naoqi_driver/naoqi_moveto.py
+++ b/naoqi_driver_py/src/naoqi_driver/naoqi_moveto.py
@@ -29,12 +29,15 @@ from tf.transformations import euler_from_quaternion
 class MoveToListener(NaoqiNode):
 
     def __init__(self):
+        global cmd_vel_topic, move_base_simple_topic
         NaoqiNode.__init__(self, 'naoqi_moveto_listener')
         self.connectNaoQi()
         self.listener = tf.TransformListener()
+        cmd_vel_topic = rospy.get_param('cmd_vel_topic')
+        move_base_simple_topic = rospy.get_param('move_base_simple_topic')
 
-        self.goal_sub = rospy.Subscriber("/move_base_simple/goal", PoseStamped, self.goalCB)
-        self.cvel_sub = rospy.Subscriber("/cmd_vel", Twist, self.cvelCB)
+        self.goal_sub = rospy.Subscriber(move_base_simple_topic, PoseStamped, self.goalCB)
+        self.cvel_sub = rospy.Subscriber(cmd_vel_topic, Twist, self.cvelCB)
 
     # (re-) connect to NaoQI:
     def connectNaoQi(self):


### PR DESCRIPTION
When you are working with more than one NAO, and you need to control them with the same pc, its common to use namespaces for each robot. Using topic name as parameter you can define different topics to control each robot