### PR TITLE
[naoqi_apps] add node and launch for ALListeningMovement

### DIFF
--- a/naoqi_apps/launch/listening_movement.launch
+++ b/naoqi_apps/launch/listening_movement.launch
@@ -1,0 +1,12 @@
+<launch>
+  <!--
+      This pushes the local PYTHONPATH into the launch file, so that the NaoQI API is found.
+      You need to add the Nao's API dir to your PYTHONPATH so that the modules are found.
+  -->
+  <env name="PYTHONPATH" value="$(env PYTHONPATH)" />
+
+  <arg name="nao_ip" default="$(optenv NAO_IP 127.0.0.1)" />
+  <arg name="nao_port" default="$(optenv NAO_PORT 9559)" />
+  
+  <node pkg="naoqi_apps" type="naoqi_listening_movement.py" name="naoqi_listening_movement" required="true" args="--pip=$(arg nao_ip) --pport=$(arg nao_port)"  />
+</launch>

--- a/naoqi_apps/nodes/naoqi_listening_movement.py
+++ b/naoqi_apps/nodes/naoqi_listening_movement.py
@@ -24,6 +24,7 @@ from std_srvs.srv import (
     TriggerResponse,
     Trigger
 )
+from distutils.version import LooseVersion
 
 class NaoqiListeningMovement(NaoqiNode):
     def __init__(self):
@@ -36,10 +37,19 @@ class NaoqiListeningMovement(NaoqiNode):
 
     def connectNaoQi(self):
         rospy.loginfo("Connecting to NaoQi at %s:%d", self.pip, self.pport)
-        self.listeningMovementProxy = self.get_proxy("ALListeningMovement")
-        if self.listeningMovementProxy is None:
-            rospy.logerr("Could not get a proxy to ALListeningMovement")
+        self.systemProxy = self.get_proxy("ALSystem")
+        if self.systemProxy is None:
+            rospy.logerr("Could not get a proxy to ALSystem")
             exit(1)
+        else:
+            if LooseVersion(self.systemProxy.systemVersion()) < LooseVersion("2.4"):
+                rospy.logerr("Naoqi version of your robot is " + str(self.systemProxy.systemVersion()) + ", which doesn't have a proxy to ALListeningMovement.")
+                exit(1)
+            else:
+                self.listeningMovementProxy = self.get_proxy("ALListeningMovement")
+                if self.listeningMovementProxy is None:
+                    rospy.logerr("Could not get a proxy to ALListeningMovement")
+                    exit(1)
     
     def handleSetEnabledSrv(self, req):
         res = SetBoolResponse()

--- a/naoqi_apps/nodes/naoqi_listening_movement.py
+++ b/naoqi_apps/nodes/naoqi_listening_movement.py
@@ -18,20 +18,20 @@
 # 
 import rospy
 from naoqi_driver.naoqi_node import NaoqiNode
-from naoqi_bridge_msgs.srv import ( 
-    IsActiveResponse,
-    IsActive,
-    SetEnabledResponse,
-    SetEnabled,)
+from std_srvs.srv import (
+    SetBoolResponse,
+    SetBool,
+    TriggerResponse,
+    Trigger
+)
 
 class NaoqiListeningMovement(NaoqiNode):
     def __init__(self):
         NaoqiNode.__init__(self, 'naoqi_listening_movement')
         self.connectNaoQi()
         
-        self.SetEnabledSrv = rospy.Service("listening_movement_set_enabled", SetEnabled, self.handleSetEnabledSrv)
-        self.IsEnabledSrv = rospy.Service("listening_movement_is_enabled", IsActive, self.handleIsEnabledSrv)
-        self.IsRunningSrv = rospy.Service("listening_movement_is_running", IsActive, self.handleIsRunningSrv)
+        self.SetEnabledSrv = rospy.Service("listening_movement_set_enabled", SetBool, self.handleSetEnabledSrv)
+        self.IsEnabledSrv = rospy.Service("listening_movement_is_enabled", Trigger, self.handleIsEnabledSrv)
         rospy.loginfo("naoqi_listening_movement initialized")
 
     def connectNaoQi(self):
@@ -41,10 +41,10 @@ class NaoqiListeningMovement(NaoqiNode):
             exit(1)
     
     def handleSetEnabledSrv(self, req):
-        res = SetEnabledResponse()
+        res = SetBoolResponse()
         res.success = False
         try:
-            self.listeningMovementProxy.setEnabled(req.enabled)
+            self.listeningMovementProxy.setEnabled(req.data)
             res.success = True
             return res
         except RuntimeError, e:
@@ -53,17 +53,8 @@ class NaoqiListeningMovement(NaoqiNode):
 
     def handleIsEnabledSrv(self, req):
         try:
-            res = IsActiveResponse()
-            res.status = self.listeningMovementProxy.isEnabled()
-            return  res
-        except RuntimeError, e:
-            rospy.logerr("Exception caught:\n%s", e)
-            return None
-
-    def handleIsRunningSrv(self, req):
-        try:
-            res = IsActiveResponse()
-            res.status = self.listeningMovementProxy.isRunning()
+            res = TriggerResponse()
+            res.success = self.listeningMovementProxy.isEnabled()
             return  res
         except RuntimeError, e:
             rospy.logerr("Exception caught:\n%s", e)

--- a/naoqi_apps/nodes/naoqi_listening_movement.py
+++ b/naoqi_apps/nodes/naoqi_listening_movement.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+
+#                                                                             
+#  Copyright 2016 Aldebaran                                                   
+#                                                                             
+#  Licensed under the Apache License, Version 2.0 (the "License");            
+#  you may not use this file except in compliance with the License.           
+#  You may obtain a copy of the License at                                    
+#                                                                             
+#      http://www.apache.org/licenses/LICENSE-2.0                             
+#                                                                             
+#  Unless required by applicable law or agreed to in writing, software        
+#  distributed under the License is distributed on an "AS IS" BASIS,          
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   
+#  See the License for the specific language governing permissions and        
+#  limitations under the License.                                             
+#                                                                             
+# 
+import rospy
+from naoqi_driver.naoqi_node import NaoqiNode
+from naoqi_bridge_msgs.srv import ( 
+    IsActiveResponse,
+    IsActive,
+    SetEnabledResponse,
+    SetEnabled,)
+
+class NaoqiListeningMovement(NaoqiNode):
+    def __init__(self):
+        NaoqiNode.__init__(self, 'naoqi_listening_movement')
+        self.connectNaoQi()
+        
+        self.SetEnabledSrv = rospy.Service("listening_movement_set_enabled", SetEnabled, self.handleSetEnabledSrv)
+        self.IsEnabledSrv = rospy.Service("listening_movement_is_enabled", IsActive, self.handleIsEnabledSrv)
+        self.IsRunningSrv = rospy.Service("listening_movement_is_running", IsActive, self.handleIsRunningSrv)
+        rospy.loginfo("naoqi_listening_movement initialized")
+
+    def connectNaoQi(self):
+        rospy.loginfo("Connecting to NaoQi at %s:%d", self.pip, self.pport)
+        self.listeningMovementProxy = self.get_proxy("ALListeningMovement")
+        if self.listeningMovementProxy is None:
+            exit(1)
+    
+    def handleSetEnabledSrv(self, req):
+        res = SetEnabledResponse()
+        res.success = False
+        try:
+            self.listeningMovementProxy.setEnabled(req.enabled)
+            res.success = True
+            return res
+        except RuntimeError, e:
+            rospy.logerr("Exception caught:\n%s", e)
+            return res
+
+    def handleIsEnabledSrv(self, req):
+        try:
+            res = IsActiveResponse()
+            res.status = self.listeningMovementProxy.isEnabled()
+            return  res
+        except RuntimeError, e:
+            rospy.logerr("Exception caught:\n%s", e)
+            return None
+
+    def handleIsRunningSrv(self, req):
+        try:
+            res = IsActiveResponse()
+            res.status = self.listeningMovementProxy.isRunning()
+            return  res
+        except RuntimeError, e:
+            rospy.logerr("Exception caught:\n%s", e)
+            return None
+
+    def run(self):
+        while self.is_looping():
+            try:
+                pass
+            except RuntimeError, e:
+                print "Error accessing ALListeningMovement, exiting...\n"
+                print e
+                rospy.signal_shutdown("No NaoQI available anymore")
+
+if __name__ == '__main__':
+    listening_movement = NaoqiListeningMovement()
+    listening_movement.start()
+    rospy.spin()

--- a/naoqi_apps/nodes/naoqi_listening_movement.py
+++ b/naoqi_apps/nodes/naoqi_listening_movement.py
@@ -30,14 +30,15 @@ class NaoqiListeningMovement(NaoqiNode):
         NaoqiNode.__init__(self, 'naoqi_listening_movement')
         self.connectNaoQi()
         
-        self.SetEnabledSrv = rospy.Service("listening_movement_set_enabled", SetBool, self.handleSetEnabledSrv)
-        self.IsEnabledSrv = rospy.Service("listening_movement_is_enabled", Trigger, self.handleIsEnabledSrv)
+        self.SetEnabledSrv = rospy.Service("listening_movement/set_enabled", SetBool, self.handleSetEnabledSrv)
+        self.IsEnabledSrv = rospy.Service("listening_movement/is_enabled", Trigger, self.handleIsEnabledSrv)
         rospy.loginfo("naoqi_listening_movement initialized")
 
     def connectNaoQi(self):
         rospy.loginfo("Connecting to NaoQi at %s:%d", self.pip, self.pport)
         self.listeningMovementProxy = self.get_proxy("ALListeningMovement")
         if self.listeningMovementProxy is None:
+            rospy.logerr("Could not get a proxy to ALListeningMovement")
             exit(1)
     
     def handleSetEnabledSrv(self, req):
@@ -60,16 +61,6 @@ class NaoqiListeningMovement(NaoqiNode):
             rospy.logerr("Exception caught:\n%s", e)
             return None
 
-    def run(self):
-        while self.is_looping():
-            try:
-                pass
-            except RuntimeError, e:
-                print "Error accessing ALListeningMovement, exiting...\n"
-                print e
-                rospy.signal_shutdown("No NaoQI available anymore")
-
 if __name__ == '__main__':
     listening_movement = NaoqiListeningMovement()
-    listening_movement.start()
     rospy.spin()


### PR DESCRIPTION
This is for http://doc.aldebaran.com/2-4/naoqi/interaction/autonomousabilities/allisteningmovement-api.html#allisteningmovement-api.

memo: 
- It needs SetEnabled.srv in https://github.com/ros-naoqi/naoqi_bridge_msgs/pull/30
- IsActive.srv is in ALTracker related pull-request, (https://github.com/ros-naoqi/naoqi_bridge_msgs/pull/27)
and I'm thinking that I have to rename it for general use. 
- It is something wrong with isRunning method.
```
rosservice call /listening_movement_is_running
[ERROR] [WallTime: 1478745757.759069] Error processing request: proxy_isRunning() takes exactly 2 arguments (1 given)
['Traceback (most recent call last):\n', '  File "/opt/ros/indigo/lib/python2.7/dist-packages/rospy/impl/tcpros_service.py", line 623, in _handle_request\n    response = convert_return_to_response(self.handler(request), self.response_class)\n', '  File "/home/kochigami/catkin_ws/src/naoqi_bridge/naoqi_apps/nodes/naoqi_listening_movement.py", line 66, in handleIsRunningSrv\n    res.status = self.listeningMovementProxy.isRunning()\n', '  File "/home/kochigami/naoqi/pynaoqi-python2.7-2.1.0.19-linux64/inaoqi.py", line 326, in isRunning\n    def isRunning(self, *args): return _inaoqi.proxy_isRunning(self, *args)\n', 'TypeError: proxy_isRunning() takes exactly 2 arguments (1 given)\n']
```