### PR TITLE
Avoid 100% cpu usage in naoqi_sonar.py when waiting for subscribers

### DIFF
--- a/naoqi_sensors_py/src/naoqi_sensors/naoqi_sonar.py
+++ b/naoqi_sensors_py/src/naoqi_sensors/naoqi_sonar.py
@@ -85,8 +85,9 @@ class SonarPublisher(NaoqiNode):
 
                 # publish messages
                 self.publisher.publish(sonar.msg)
-                #sleep
-                self.sonarRate.sleep()
+
+            #sleep
+            self.sonarRate.sleep()
 
         #exit sonar subscription
         #self.sonarProxy.unsubscribe(self.NAOQI_SONAR_SUB_NAME)


### PR DESCRIPTION
In naoqi_sonar.py's main loop, the rate.sleep() was only done when there was a subscriber.
No need to loop like madness using 100% cpu do to nothing but waiting for a subscriber.

With pepper there is two sonar, so two process using 100% of a cpu core each.