### PR TITLE
[naoqi_apps] add background_movement

### DIFF
--- a/naoqi_apps/launch/background_movement.launch
+++ b/naoqi_apps/launch/background_movement.launch
@@ -1,0 +1,12 @@
+<launch>
+  <!--
+      This pushes the local PYTHONPATH into the launch file, so that the NaoQI API is found.
+      You need to add the Nao's API dir to your PYTHONPATH so that the modules are found.
+  -->
+  <env name="PYTHONPATH" value="$(env PYTHONPATH)" />
+
+  <arg name="nao_ip" default="$(optenv NAO_IP 127.0.0.1)" />
+  <arg name="nao_port" default="$(optenv NAO_PORT 9559)" />
+  
+  <node pkg="naoqi_apps" type="naoqi_background_movement.py" name="naoqi_background_movement" required="true" args="--pip=$(arg nao_ip) --pport=$(arg nao_port)"  />
+</launch>

--- a/naoqi_apps/nodes/naoqi_background_movement.py
+++ b/naoqi_apps/nodes/naoqi_background_movement.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+
+#                                                                             
+#  Copyright 2017 Aldebaran                                                   
+#                                                                             
+#  Licensed under the Apache License, Version 2.0 (the "License");            
+#  you may not use this file except in compliance with the License.           
+#  You may obtain a copy of the License at                                    
+#                                                                             
+#      http://www.apache.org/licenses/LICENSE-2.0                             
+#                                                                             
+#  Unless required by applicable law or agreed to in writing, software        
+#  distributed under the License is distributed on an "AS IS" BASIS,          
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   
+#  See the License for the specific language governing permissions and        
+#  limitations under the License.                                             
+#                                                                             
+# 
+import rospy
+from naoqi_driver.naoqi_node import NaoqiNode
+from std_srvs.srv import (
+    SetBoolResponse, 
+    SetBool,
+    TriggerResponse,
+    Trigger
+)
+
+class NaoqiBackgroundMovement(NaoqiNode):
+    def __init__(self):
+        NaoqiNode.__init__(self, 'naoqi_background_movement')
+        self.connectNaoQi()
+        
+        self.SetEnabledSrv = rospy.Service("background_movement_set_enabled", SetBool, self.handleSetEnabledSrv)
+        self.IsEnabledSrv = rospy.Service("background_movement_is_enabled", Trigger, self.handleIsEnabledSrv)
+        rospy.loginfo("naoqi_background_movement initialized")
+
+    def connectNaoQi(self):
+        rospy.loginfo("Connecting to NaoQi at %s:%d", self.pip, self.pport)
+        self.backgroundMovementProxy = self.get_proxy("ALBackgroundMovement")
+        if self.backgroundMovementProxy is None:
+            exit(1)
+    
+    def handleSetEnabledSrv(self, req):
+        res = SetBoolResponse()
+        res.success = False
+        try:
+            self.backgroundMovementProxy.setEnabled(req.data)
+            res.success = True
+            return res
+        except RuntimeError, e:
+            rospy.logerr("Exception caught:\n%s", e)
+            return res
+
+    def handleIsEnabledSrv(self, req):
+        try:
+            res = TriggerResponse()
+            res.success = self.backgroundMovementProxy.isEnabled()
+            return res
+        except RuntimeError, e:
+            rospy.logerr("Exception caught:\n%s", e)
+            return None
+
+    def run(self):
+        while self.is_looping():
+            try:
+                pass
+            except RuntimeError, e:
+                print "Error accessing ALBackgroundMovement, exiting...\n"
+                print e
+                rospy.signal_shutdown("No NaoQI available anymore")
+
+if __name__ == '__main__':
+    background_movement = NaoqiBackgroundMovement()
+    background_movement.start()
+    rospy.spin()

--- a/naoqi_apps/nodes/naoqi_background_movement.py
+++ b/naoqi_apps/nodes/naoqi_background_movement.py
@@ -24,6 +24,7 @@ from std_srvs.srv import (
     TriggerResponse,
     Trigger
 )
+from distutils.version import LooseVersion
 
 class NaoqiBackgroundMovement(NaoqiNode):
     def __init__(self):
@@ -36,10 +37,19 @@ class NaoqiBackgroundMovement(NaoqiNode):
 
     def connectNaoQi(self):
         rospy.loginfo("Connecting to NaoQi at %s:%d", self.pip, self.pport)
-        self.backgroundMovementProxy = self.get_proxy("ALBackgroundMovement")
-        if self.backgroundMovementProxy is None:
-            rospy.logerr("Could not get a proxy to ALBackgroundMovement")
+        self.systemProxy = self.get_proxy("ALSystem")
+        if self.systemProxy is None:
+            rospy.logerr("Could not get a proxy to ALSystem")
             exit(1)
+        else:
+            if LooseVersion(self.systemProxy.systemVersion()) < LooseVersion("2.4"):
+                rospy.logerr("Naoqi version of your robot is " + str(self.systemProxy.systemVersion()) + ", which doesn't have a proxy to ALBackgroundMovement.")
+                exit(1)
+            else:
+                self.backgroundMovementProxy = self.get_proxy("ALBackgroundMovement")
+                if self.backgroundMovementProxy is None:
+                    rospy.logerr("Could not get a proxy to ALBackgroundMovement.")
+                    exit(1)
     
     def handleSetEnabledSrv(self, req):
         res = SetBoolResponse()

--- a/naoqi_apps/nodes/naoqi_background_movement.py
+++ b/naoqi_apps/nodes/naoqi_background_movement.py
@@ -30,14 +30,15 @@ class NaoqiBackgroundMovement(NaoqiNode):
         NaoqiNode.__init__(self, 'naoqi_background_movement')
         self.connectNaoQi()
         
-        self.SetEnabledSrv = rospy.Service("background_movement_set_enabled", SetBool, self.handleSetEnabledSrv)
-        self.IsEnabledSrv = rospy.Service("background_movement_is_enabled", Trigger, self.handleIsEnabledSrv)
+        self.SetEnabledSrv = rospy.Service("background_movement/set_enabled", SetBool, self.handleSetEnabledSrv)
+        self.IsEnabledSrv = rospy.Service("background_movement/is_enabled", Trigger, self.handleIsEnabledSrv)
         rospy.loginfo("naoqi_background_movement initialized")
 
     def connectNaoQi(self):
         rospy.loginfo("Connecting to NaoQi at %s:%d", self.pip, self.pport)
         self.backgroundMovementProxy = self.get_proxy("ALBackgroundMovement")
         if self.backgroundMovementProxy is None:
+            rospy.logerr("Could not get a proxy to ALBackgroundMovement")
             exit(1)
     
     def handleSetEnabledSrv(self, req):
@@ -60,16 +61,6 @@ class NaoqiBackgroundMovement(NaoqiNode):
             rospy.logerr("Exception caught:\n%s", e)
             return None
 
-    def run(self):
-        while self.is_looping():
-            try:
-                pass
-            except RuntimeError, e:
-                print "Error accessing ALBackgroundMovement, exiting...\n"
-                print e
-                rospy.signal_shutdown("No NaoQI available anymore")
-
 if __name__ == '__main__':
     background_movement = NaoqiBackgroundMovement()
-    background_movement.start()
     rospy.spin()


### PR DESCRIPTION
reference: http://doc.aldebaran.com/2-5/naoqi/interaction/autonomousabilities/albackgroundmovement-api.html#albackgroundmovement-api

I only added ```isEnabled```, ```setEnabled```. 
I didn't add ```isRunning``` because of the error below:
(Based on the documentation, I couldn't know what the correct argument is. It seems that it says no argument is taken to the function.)
```
[ERROR] [WallTime: 1501663733.674299] Error processing request: proxy_isRunning() takes exactly 2 arguments (1 given)
['Traceback (most recent call last):\n', '  File "/opt/ros/indigo/lib/python2.7/dist-packages/rospy/impl/tcpros_service.py", line 623, in _handle_request\n    response = convert_return_to_response(self.handler(request), self.response_class)\n', '  File "/home/kochigami/catkin_ws/src/naoqi_bridge/naoqi_apps/nodes/naoqi_background_movement.py", line 67, in handleIsRunningSrv\n    res.success = self.backgroundMovementProxy.isRunning()\n', '  File "/home/kochigami/pynaoqi/pynaoqi-python2.7-2.4.3.28-linux64/inaoqi.py", line 278, in isRunning\n    def isRunning(self, *args): return _inaoqi.proxy_isRunning(self, *args)\n', 'TypeError: proxy_isRunning() takes exactly 2 arguments (1 given)\n']
```
