### PR TITLE
Fix bug where microphone sensor would use 100% CPU while waiting for subscribers

### DIFF
--- a/naoqi_sensors_py/src/naoqi_sensors/naoqi_microphone.py
+++ b/naoqi_sensors_py/src/naoqi_sensors/naoqi_microphone.py
@@ -85,13 +85,11 @@ class NaoqiMic (ALModule, NaoqiNode):
     def run(self):
         r=rospy.Rate(2)
         while self.is_looping():
-            if self.pub_audio_.get_num_connections() == 0:
-                if self.isSubscribed:
-                    rospy.loginfo('Unsubscribing from audio bridge as nobody listens to the topics.')
-                    self.release()
-                continue
+            if self.pub_audio_.get_num_connections() == 0 and self.isSubscribed:
+                rospy.loginfo('Unsubscribing from audio bridge as nobody listens to the topics.')
+                self.release()
 
-            if not self.isSubscribed:
+            elif self.pub_audio_.get_num_connections() > 0 and not self.isSubscribed:
                 self.reconfigure(self.config, 0)
 
             r.sleep()


### PR DESCRIPTION
Previous code was keeping the CPU pegged at 100% usage when no connections as the loop would continue before hitting sleep. Reorganised so it always sleeps no matter what, which results in much lower CPU usage. Ran into this issue testing with using naoqi as a virtual robot.