### PR TITLE
modifying to give self.rate value by using rospy function

### DIFF
--- a/naoqi_pose/nodes/pose_controller.py
+++ b/naoqi_pose/nodes/pose_controller.py
@@ -58,7 +58,7 @@ class PoseController(NaoqiNode):
 
         self.connectNaoQi()
 
-        self.rate = 10
+        self.rate = rospy.Rate(10) 
 
         # store the number of joints in each motion chain and collection, used for sanity checks
         self.collectionSize = {}


### PR DESCRIPTION
I modified a line to give self.rate value by using the rospy.Rate function that is given as a constant now.

This PR fix an error in 'pepper_full_py.launch'

Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/home/cylee/catkin_ws/src/naoqi_bridge/naoqi_pose/nodes/pose_controller.py", line 441, in run
    self.rate.sleep()
AttributeError: 'int' object has no attribute 'sleep'


@nlyubova, @kochigami and @k-okada would you agree to merge it?
