### PR TITLE
fix range of auto_exposure_algo parameter

### DIFF
--- a/naoqi_sensors_py/cfg/NaoqiCamera.cfg
+++ b/naoqi_sensors_py/cfg/NaoqiCamera.cfg
@@ -102,7 +102,7 @@ gen.add("auto_exposition", int_t, SensorLevels.RECONFIGURE_RUNNING,
         "Auto exposition.", 1, 0, 1, edit_method = controls)
 
 gen.add("auto_exposure_algo", int_t, SensorLevels.RECONFIGURE_RUNNING,
-        "Auto Exposure Algorithm.", 1, 0, 0, edit_method = exposure_algos)
+        "Auto Exposure Algorithm.", 1, 0, 3, edit_method = exposure_algos)
 
 gen.add("exposure", int_t, SensorLevels.RECONFIGURE_RUNNING,
         "Exposure (time in ms = (value * 2) / 5) (disables auto exposition)", 128, 0, 512)


### PR DESCRIPTION
While the enum `exposure_algos` defines 4 values from 0 to 3: https://github.com/ros-naoqi/naoqi_bridge/blob/2bb282b5c063a40f0ba38e525c3cb5dfdb854584/naoqi_sensors_py/cfg/NaoqiCamera.cfg#L88-L93.

This PR changes the default value from 0 to  3.

This has been flagged by https://github.com/ros/dynamic_reconfigure/pull/111